### PR TITLE
Fixed an issue that caused a large number of empty rows in the system crontab table

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -83,6 +83,7 @@ cronset(){
 	sed -i '/^$/d' $crondir
 	if [ -n "$2" ] && [ "$2" != "\n" ];then
                 echo "$2" >> $crondir
+	fi
 	crontab $crondir
 	rm -f $crondir
 }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+﻿#!/bin/sh
 # Copyright (C) Juewuy
 
 #脚本内部工具
@@ -81,7 +81,8 @@ cronset(){
 	crontab -l > $crondir
 	sed -i "/$1/d" $crondir
 	sed -i '/^$/d' $crondir
-	echo "$2" >> $crondir
+	if [ -n "$2" ] && [ "$2" != "\n" ];then
+                	echo "$2" >> $crondir
 	crontab $crondir
 	rm -f $crondir
 }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -82,7 +82,7 @@ cronset(){
 	sed -i "/$1/d" $crondir
 	sed -i '/^$/d' $crondir
 	if [ -n "$2" ] && [ "$2" != "\n" ];then
-                	echo "$2" >> $crondir
+                echo "$2" >> $crondir
 	crontab $crondir
 	rm -f $crondir
 }


### PR DESCRIPTION
每次重启shellclash，crontab都会多出两行空行
定位问题出在/scripts/start.sh stop) case下
cronset "clash保守模式守护进程"
cronset "保存节点配置"
cronset函数两个参数，删除第一个，写入第二个
而写入第二个参数前未做参数校验
第二个参数为 '' or '\n' 时，不应写入crontab中

此次修改在红米AX6上测试有效且修改后未影响其它功能