### PR TITLE
PREROUTING google dns

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -369,8 +369,8 @@ start_dns(){
 	fi
 	iptables -t nat -A PREROUTING -p udp -j clash_dns
 	#Google home DNS特殊处理
-	iptables -t nat -I PREROUTING -p tcp -d 8.8.8.8 -j clash_dns
-	iptables -t nat -I PREROUTING -p tcp -d 8.8.4.4 -j clash_dns
+	iptables -t nat -I PREROUTING -p udp -d 8.8.8.8 -j clash_dns
+	iptables -t nat -I PREROUTING -p udp -d 8.8.4.4 -j clash_dns
 	#ipv6DNS
 	ip6_nat=$(ip6tables -t nat -L 2>&1 | grep -o 'Chain')
 	if [ -n "$ip6_nat" ];then


### PR DESCRIPTION
dns查询都是走的udp，不是tcp