### PR TITLE
Update clash.sh

### DIFF
--- a/scripts/clash.sh
+++ b/scripts/clash.sh
@@ -93,7 +93,7 @@ getconfig(){
 setconfig(){
 	#参数1代表变量名，参数2代表变量值,参数3即文件路径
 	[ -z "$3" ] && configpath=$clashdir/mark || configpath=$3
-	[ -n "$(grep ${1} $configpath)" ] && sed -i "s#${1}=\(.*\)#${1}=${2}#g" $configpath || echo "${1}=${2}" >> $configpath
+	[ -n "$(grep ${1}= $configpath)" ] && sed -i "s#${1}=\(.*\)#${1}=${2}#g" $configpath || echo "${1}=${2}" >> $configpath
 }
 #启动相关
 errornum(){


### PR DESCRIPTION
BUG修复：

**clash** > **7 clash进阶设置** > **6 手动指定相关端口、秘钥及本机host** > **8 指定本机host地址**

```text
hostdir=':9999/ui'
host='127.0.0.1'
```

修改后的匹配方案虽然仍有不足但暂且够用。