### PR TITLE
Change group id to match iptable rules

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -658,6 +658,7 @@ bfstart(){
 		if [ -z "$(id shellclash 2>/dev/null | grep 'root')" ];then
 			userdel shellclash 2>/dev/null
 			useradd shellclash -u 7890
+			groupmod shellclash -g 7890
 			sed -Ei s/7890:7890/0:7890/g /etc/passwd
 		fi
 		if [ "$start_old" != "已开启" ];then


### PR DESCRIPTION
一些Linux上指定uid创建用户后gid并不等于uid，比如我使用CentOS Linux release 7.9.2009 (Core)，执行脚本后创建的shellclash用户的gid是10007，导致iptables规则不匹配出现流量死循环，因此增加了一条命令修改gid以匹配iptables规则。