### PR TITLE
修复安装正式版时 update_url 有误的问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ webget(){
 	fi
 }
 #检查更新
-[ -z "$url" ] && url="https://cdn.jsdelivr.net/gh/juewuy/ShellClash"
+[ -z "$url" ] && url="https://cdn.jsdelivr.net/gh/juewuy/ShellClash@master"
 #选择版本
 echo -----------------------------------------------
 $echo "\033[33m请选择想要安装的版本：\033[0m"	
@@ -54,21 +54,14 @@ if [ -z $num ];then
 	echo 安装已取消
 	exit 1;
 elif [ "$num" = "1" ];then
-	webget /tmp/clashrelease $url/bin/release_version echoon rediroff 2>/tmp/clashrelease
-	if [ "$result" = "200" ];then
-		release_new=$(cat /tmp/clashrelease | head -1)
-		url2="https://cdn.jsdelivr.net/gh/juewuy/ShellClash@$release_new"
-	else
-		echo "无法切换版本，尝试安装测试版！"
-	fi
+	url="https://cdn.jsdelivr.net/gh/juewuy/ShellClash"
 fi
-[ -z "$url2" ] && url2=$url
-webget /tmp/clashversion "$url2/bin/version" echooff
+webget /tmp/clashversion "$url/bin/version" echooff
 [ "$result" = "200" ] && versionsh=$(cat /tmp/clashversion | grep "versionsh" | awk -F "=" '{print $2}')
 [ -z "$release_new" ] && release_new=$versionsh
 rm -rf /tmp/clashversion
 rm -rf /tmp/clashrelease
-tarurl=$url2/bin/clashfm.tar.gz
+tarurl=$url/bin/clashfm.tar.gz
 
 gettar(){
 	webget /tmp/clashfm.tar.gz $tarurl


### PR DESCRIPTION
使用 README.md 给出的命令：
```shell
#By github-CDN
export url='https://raw.githubusercontent.com/juewuy/ShellClash/master' && sh -c "$(curl -kfsSl $url/install.sh)" && source /etc/profile &> /dev/null
#By jsdelivrCDN
export url='https://cdn.jsdelivr.net/gh/juewuy/ShellClash@master' && sh -c "$(curl -kfsSl $url/install.sh)" && source /etc/profile &> /dev/null
```
进行安装，记录在 mark 文件中的 update_url 会被赋值为上述命令中 export 的 url，进而造成安装“正式版”而安装时拉取的控制面板等文件，以及手动检测更新的内容为 master 分支的“测试版”