### PR TITLE
适配ax6s小米镜像化系统设备使用iptables增强模式开启本机代理

### DIFF
--- a/scripts/clash.sh
+++ b/scripts/clash.sh
@@ -562,6 +562,9 @@ localproxy(){
 		if [ -w /etc/systemd/system/clash.service -o -w /usr/lib/systemd/system/clash.service -o -x /bin/su ];then
 			local_type="iptables增强模式"
 			setconfig local_type $local_type
+		elif [ -f /etc/rc.common -a -w /etc/passwd ]; then
+			local_type="iptables增强模式"
+			setconfig local_type $local_type
 		else
 			echo -e "\033[31m当前设备无法使用增强模式！\033[0m"
 			sleep 1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -550,19 +550,27 @@ start_output(){
 	#流量过滤规则
 	iptables -t nat -N clash_out
 	iptables -t nat -A clash_out -m owner --gid-owner 7890 -j RETURN
+	iptables -t nat -A clash_out -d 0.0.0.0/8 -j RETURN
+	iptables -t nat -A clash_out -d 10.0.0.0/8 -j RETURN
+	iptables -t nat -A clash_out -d 100.64.0.0/10 -j RETURN
 	iptables -t nat -A clash_out -d 127.0.0.0/8 -j RETURN
+	iptables -t nat -A clash_out -d 169.254.0.0/16 -j RETURN
 	iptables -t nat -A clash_out -d 172.16.0.0/12 -j RETURN
+	iptables -t nat -A clash_out -d 192.0.0.0/24 -j RETURN
+	iptables -t nat -A clash_out -d 192.168.0.0/16 -j RETURN
+	iptables -t nat -A clash_out -d 224.0.0.0/4 -j RETURN
+	iptables -t nat -A clash_out -d 240.0.0.0/4 -j RETURN
+	iptables -t nat -A clash_out -d 255.255.255.255/32 -j RETURN
 	[ "$dns_mod" = "redir_host" -a "$cn_ip_route" = "已开启" ] && iptables -t nat -A clash_out -m set --match-set cn_ip dst -j RETURN >/dev/null 2>&1 #绕过大陆IP
 	iptables -t nat -A clash_out -p tcp -j REDIRECT --to-ports $redir_port
-	iptables -t nat -A OUTPUT -p tcp -s 127.0.0.0/8 -j clash_out
-	iptables -t nat -A OUTPUT -p tcp -s 172.16.0.0/12 -j clash_out
-	iptables -t nat -A OUTPUT -p tcp -d 198.18.0.0/16 -j clash_out
+	iptables -t nat -A OUTPUT -p tcp -j clash_out
 	#设置dns转发
-	iptables -t nat -N clash_dns_out
-	iptables -t nat -A clash_dns_out -m owner --gid-owner 7890 -j RETURN
-	iptables -t nat -A clash_dns_out -p udp -j REDIRECT --to $dns_port
-	iptables -t nat -A OUTPUT -p udp --dport 53 -s 127.0.0.0/8 -j clash_dns_out
-	iptables -t nat -A OUTPUT -p udp --dport 53 -s 172.16.0.0/12 -j clash_dns_out
+	[ "$dns_no" != "已禁用" ] && {
+		iptables -t nat -N clash_dns_out
+		iptables -t nat -A clash_dns_out -m owner --gid-owner 7890 -j RETURN
+		iptables -t nat -A clash_dns_out -p udp -j REDIRECT --to $dns_port
+		iptables -t nat -A OUTPUT -p udp --dport 53 -j clash_dns_out
+	}
 }
 start_tun(){
 	if [ "$quic_rj" = 已启用 ];then
@@ -612,10 +620,12 @@ stop_iptables(){
 	iptables -t nat -D OUTPUT -p tcp -s 127.0.0.0/8 -j clash_out 2> /dev/null
 	iptables -t nat -D OUTPUT -p tcp -s 172.16.0.0/12 -j clash_out 2> /dev/null
 	iptables -t nat -D OUTPUT -p tcp -d 198.18.0.0/16 -j clash_out 2> /dev/null
+	iptables -t nat -D OUTPUT -p tcp -j clash_out 2> /dev/null
 	iptables -t nat -F clash_out 2> /dev/null
 	iptables -t nat -X clash_out 2> /dev/null	
 	iptables -t nat -D OUTPUT -p udp --dport 53 -s 127.0.0.0/8 -j clash_dns_out 2> /dev/null
 	iptables -t nat -D OUTPUT -p udp --dport 53 -s 172.16.0.0/12 -j clash_dns_out 2> /dev/null
+	iptables -t nat -D OUTPUT -p udp --dport 53 -j clash_dns_out 2> /dev/null
 	iptables -t nat -F clash_dns_out 2> /dev/null
 	iptables -t nat -X clash_dns_out 2> /dev/null
 	#重置udp规则
@@ -806,16 +816,27 @@ bfstart(){
 	#本机代理准备
 	if [ "$local_proxy" = "已开启" -a "$local_type" = "iptables增强模式" ];then
 		if [ -z "$(id shellclash 2>/dev/null | grep 'root')" ];then
-			userdel shellclash 2>/dev/null
-			useradd shellclash -u 7890
-			groupmod shellclash -g 7890
-			sed -Ei s/7890:7890/0:7890/g /etc/passwd
+			if [ -z "$(command -v useradd 2>/dev/null)" -o -z "$(command -v groupmod 2>/dev/null)" ]; then
+				grep -qw shellclash /etc/passwd || echo "shellclash:x:0:7890:::" >> /etc/passwd
+			else
+				userdel shellclash 2>/dev/null
+				useradd shellclash -u 7890
+				groupmod shellclash -g 7890
+				sed -Ei s/7890:7890/0:7890/g /etc/passwd
+			fi
 		fi
 		if [ "$start_old" != "已开启" ];then
-			[ -w /etc/systemd/system/clash.service ] && servdir=/etc/systemd/system/clash.service
-			[ -w /usr/lib/systemd/system/clash.service ] && servdir=/usr/lib/systemd/system/clash.service
-			setconfig ExecStart "/bin/su\ shellclash\ -c\ \"$bindir/clash\ -d\ $bindir\"" $servdir
-			systemctl daemon-reload >/dev/null
+			if [ -w /etc/init.d/clash ]; then
+				[ "$systype" = "mi_snapshot" ] && servdir=$clashdir/clashservice || servdir=/etc/init.d/clash
+				[ -z "$(grep 'procd_set_param user shellclash' $servdir)" ] && {
+    				sed -i '/procd_close_instance/i\\t\tprocd_set_param user shellclash' $servdir
+				}
+			else
+				[ -w /etc/systemd/system/clash.service ] && servdir=/etc/systemd/system/clash.service
+				[ -w /usr/lib/systemd/system/clash.service ] && servdir=/usr/lib/systemd/system/clash.service
+				setconfig ExecStart "/bin/su\ shellclash\ -c\ \"$bindir/clash\ -d\ $bindir\"" $servdir
+				systemctl daemon-reload >/dev/null
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
适配了在红米ax6s设备上通过Iptables增强模式开启本机代理，在ax6s上测试可以正常使用