### PR TITLE
优化workflows

### DIFF
--- a/.github/workflows/bin_update.yml
+++ b/.github/workflows/bin_update.yml
@@ -83,27 +83,19 @@ jobs:
       run: |
         cd \bin
         source version
-        curl -kfSL -O https://cdn.jsdelivr.net/gh/alecthw/mmdb_china_ip_list@release/Country.mmdb
-        curl -kfSL -o cn_mini.mmdb https://cdn.jsdelivr.net/gh/Hackl0us/GeoIP2-CN@release/Country.mmdb
-        curl -kfSL -o china_ip_list.txt https://cdn.jsdelivr.net/gh/17mon/china_ip_list@master/china_ip_list.txt
-        curl -kfSL -O https://cdn.jsdelivr.net/gh/P3TERX/ca-certificates.crt@download/ca-certificates.crt
-        curl -kfSL -O https://cdn.jsdelivr.net/gh/Loyalsoldier/v2ray-rules-dat@release/geosite.dat
+        curl -kfSL -O https://raw.githubusercontent.com/alecthw/mmdb_china_ip_list/release/Country.mmdb
+        curl -kfSL -o cn_mini.mmdb https://raw.githubusercontent.com/Hackl0us/GeoIP2-CN/release/Country.mmdb
+        curl -kfSL -o china_ip_list.txt https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt
+        curl -kfSL -O https://raw.githubusercontent.com/P3TERX/ca-certificates.crt/download/ca-certificates.crt
+        curl -kfSL -O https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/geosite.dat
         sed -i '/GeoIP_v*/'d version
         echo GeoIP_v=`date '+%Y%m%d'` >> version
         echo IP数据库及根证书文件更新完成！
-        
-    - name: Update Core Version Info
-      run: |
-          chmod -R +x bin/clash*/
-          sed -i "s/meta_v=.*/meta_v=$(./bin/clash.meta/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-          sed -i "s/clashnet_v=.*/clashnet_v=$(./bin/clash.net/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-          sed -i "s/clash_v=.*/clash_v=$(./bin/clash/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-          sed -i "s/clashpre_v=.*/clashpre_v=$(./bin/clashpre/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-        
+
     - name: Commit and push
       run: |
         git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
-        git add . && git commit -m "自动更新最新Dashboard、地址库、根证书以及内核版本信息" || exit 0
+        git add . && git commit -m "自动更新最新Dashboard、地址库、根证书" || exit 0
         git push
         
     - name: Cleanup Workflow

--- a/.github/workflows/update_clash_core.yaml
+++ b/.github/workflows/update_clash_core.yaml
@@ -1,0 +1,46 @@
+name: Update Clash Core
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version of Clash, such as v1.10.6'
+        required: true
+        type: string
+env:
+  download_version: ${{ github.event.inputs.version }}
+  download_url: https://github.com/Dreamacro/clash/releases/download
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone Repository
+      uses: actions/checkout@main
+    - name: Init Dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y upx-ucl
+    - name: Download Core
+      run: |
+        archs="386 amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat"
+        mkdir tmp
+        for arch in ${archs};do
+          wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
+          chmod +x ./tmp/clash-linux-${arch}
+          if [ "${arch}" != "armv5" ];then
+            upx ./tmp/clash-linux-${arch}
+          fi
+        done
+    - name: Update
+      run: |
+        rm -fr ./bin/clash/*
+        cp ./tmp/* ./bin/clash/
+        rm -fr ./tmp
+        sed -i "s/clash_v=.*/clash_v=$(./bin/clash/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
+    - name: Commit and push
+      run: |
+        git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
+        git add . && git commit -m "更新Clash内核至${download_version}" || exit 0
+        git push
+        

--- a/.github/workflows/update_clash_core.yaml
+++ b/.github/workflows/update_clash_core.yaml
@@ -16,11 +16,11 @@ jobs:
     - name: Clone Repository
       uses: actions/checkout@main
     - name: Init Dependencies
-      env:
-        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update
-        sudo apt-get install -y upx-ucl
+        wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+        wget https://github.com/upx/upx/releases/download/v3.93/upx-3.93-amd64_linux.tar.xz
+        tar xf upx-3.96-amd64_linux.tar.xz
+        tar xf upx-3.93-amd64_linux.tar.xz
     - name: Download Core
       run: |
         archs="386 amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat"
@@ -29,9 +29,14 @@ jobs:
           wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
           chmod +x ./tmp/clash-linux-${arch}
           if [ "${arch}" != "armv5" ];then
-            upx ./tmp/clash-linux-${arch}
+            if [ "${arch}" = "mips-softfloat" ];then
+              ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${arch}
+            else
+              ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${arch}
+            fi
           fi
         done
+        rm -fr upx*
     - name: Update
       run: |
         rm -fr ./bin/clash/*

--- a/.github/workflows/update_clash_core.yaml
+++ b/.github/workflows/update_clash_core.yaml
@@ -29,7 +29,7 @@ jobs:
           wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
           chmod +x ./tmp/clash-linux-${arch}
           if [ "${arch}" != "armv5" ];then
-            if [ "${arch}" = "mips-softfloat" ];then
+            if [[ ${arch} == mips* ]];then
               ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${arch}
             else
               ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${arch}

--- a/.github/workflows/update_dotnet_core.yaml
+++ b/.github/workflows/update_dotnet_core.yaml
@@ -16,11 +16,11 @@ jobs:
     - name: Clone Repository
       uses: actions/checkout@main
     - name: Init Dependencies
-      env:
-        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update
-        sudo apt-get install -y upx-ucl
+        wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+        wget https://github.com/upx/upx/releases/download/v3.93/upx-3.93-amd64_linux.tar.xz
+        tar xf upx-3.96-amd64_linux.tar.xz
+        tar xf upx-3.93-amd64_linux.tar.xz
     - name: Download Core
       run: |
         archs="386 amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat"
@@ -29,9 +29,14 @@ jobs:
           wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
           chmod +x ./tmp/clash-linux-${arch}
           if [ "${arch}" != "armv5" ];then
-            upx ./tmp/clash-linux-${arch}
+            if [ "${arch}" = "mips-softfloat" ];then
+              ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${arch}
+            else
+              ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${arch}
+            fi
           fi
         done
+        rm -fr upx*
     - name: Update
       run: |
         rm -fr ./bin/clash.net/*

--- a/.github/workflows/update_dotnet_core.yaml
+++ b/.github/workflows/update_dotnet_core.yaml
@@ -29,7 +29,7 @@ jobs:
           wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
           chmod +x ./tmp/clash-linux-${arch}
           if [ "${arch}" != "armv5" ];then
-            if [ "${arch}" = "mips-softfloat" ];then
+            if [[ ${arch} == mips* ]];then
               ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${arch}
             else
               ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${arch}

--- a/.github/workflows/update_dotnet_core.yaml
+++ b/.github/workflows/update_dotnet_core.yaml
@@ -1,0 +1,46 @@
+name: Update DotNet Core
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version of Clash DotNet, such as v1.7.6'
+        required: true
+        type: string
+env:
+  download_version: ${{ github.event.inputs.version }}
+  download_url: https://github.com/ClashDotNetFramework/experimental-clash/releases/download
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone Repository
+      uses: actions/checkout@main
+    - name: Init Dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y upx-ucl
+    - name: Download Core
+      run: |
+        archs="386 amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat"
+        mkdir tmp
+        for arch in ${archs};do
+          wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
+          chmod +x ./tmp/clash-linux-${arch}
+          if [ "${arch}" != "armv5" ];then
+            upx ./tmp/clash-linux-${arch}
+          fi
+        done
+    - name: Update
+      run: |
+        rm -fr ./bin/clash.net/*
+        cp ./tmp/* ./bin/clash.net/
+        rm -fr ./tmp
+        sed -i "s/clashnet_v=.*/clashnet_v=$(./bin/clash.net/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
+    - name: Commit and push
+      run: |
+        git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
+        git add . && git commit -m "更新DotNet内核至${download_version}" || exit 0
+        git push
+        

--- a/.github/workflows/update_meta_core.yaml
+++ b/.github/workflows/update_meta_core.yaml
@@ -17,11 +17,11 @@ jobs:
     - name: Clone Repository
       uses: actions/checkout@main
     - name: Init Dependencies
-      env:
-        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update
-        sudo apt-get install -y upx-ucl
+        wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+        wget https://github.com/upx/upx/releases/download/v3.93/upx-3.93-amd64_linux.tar.xz
+        tar xf upx-3.96-amd64_linux.tar.xz
+        tar xf upx-3.93-amd64_linux.tar.xz
     - name: Download Core
       run: |
         if [ "${download_tag}" = "Prerelease-Alpha" ] || [ "${download_tag}" = "Prerelease-Beta" ];then
@@ -37,9 +37,14 @@ jobs:
           wget "${download_url}/${download_tag}/Clash.Meta-linux-${archs[i]}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${new_name[i]}
           chmod +x ./tmp/clash-linux-${new_name[i]}
           if [ "${archs[i]}" != "armv5" ];then
-            upx ./tmp/clash-linux-${new_name[i]}
+            if [ "${archs[i]}" = "mips-softfloat" ];then
+              ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${new_name[i]}
+            else
+              ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${new_name[i]}
+            fi
           fi
         done
+        rm -fr upx*
     - name: Update
       run: |
         rm -fr ./bin/clash.meta/*

--- a/.github/workflows/update_meta_core.yaml
+++ b/.github/workflows/update_meta_core.yaml
@@ -37,7 +37,7 @@ jobs:
           wget "${download_url}/${download_tag}/Clash.Meta-linux-${archs[i]}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${new_name[i]}
           chmod +x ./tmp/clash-linux-${new_name[i]}
           if [ "${archs[i]}" != "armv5" ];then
-            if [ "${archs[i]}" = "mips-softfloat" ];then
+            if [[ ${archs[i]} = mips* ]];then
               ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${new_name[i]}
             else
               ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${new_name[i]}

--- a/.github/workflows/update_meta_core.yaml
+++ b/.github/workflows/update_meta_core.yaml
@@ -1,0 +1,54 @@
+name: Update Meta Core
+on: 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'tag of Clash Meta, such as Prerelease-Alpha, Prerelease-Beta, v1.11.1'
+        required: true
+        type: string
+env:
+  download_tag: ${{ github.event.inputs.tag }}
+  download_version: ''
+  download_url: https://github.com/MetaCubeX/Clash.Meta/releases/download
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone Repository
+      uses: actions/checkout@main
+    - name: Init Dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y upx-ucl
+    - name: Download Core
+      run: |
+        if [ "${download_tag}" = "Prerelease-Alpha" ] || [ "${download_tag}" = "Prerelease-Beta" ];then
+          download_version=$(curl -sL https://api.github.com/repos/MetaCubeX/Clash.Meta/releases/tags/${download_tag} | grep linux-arm64 | head -n 1 | sed 's_.gz.*__;s_.*arm64-__')
+        else
+          download_version=${download_tag}
+        fi
+        echo "download_version=${download_version}" >> ${GITHUB_ENV}
+        archs=(amd64v1 armv5 armv7 arm64 mips-softfloat mipsle-hardfloat mipsle-softfloat)
+        new_name=(amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat)
+        mkdir tmp
+        for((i=0;i<7;i++));do
+          wget "${download_url}/${download_tag}/Clash.Meta-linux-${archs[i]}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${new_name[i]}
+          chmod +x ./tmp/clash-linux-${new_name[i]}
+          if [ "${archs[i]}" != "armv5" ];then
+            upx ./tmp/clash-linux-${new_name[i]}
+          fi
+        done
+    - name: Update
+      run: |
+        rm -fr ./bin/clash.meta/*
+        cp ./tmp/* ./bin/clash.meta/
+        rm -fr ./tmp
+        sed -i "s/meta_v=.*/meta_v=$(./bin/clash.meta/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
+    - name: Commit and push
+      run: |
+        git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
+        git add . && git commit -m "更新Meta内核至${download_version}" || exit 0
+        git push
+        

--- a/.github/workflows/update_prenium_core.yaml
+++ b/.github/workflows/update_prenium_core.yaml
@@ -1,0 +1,46 @@
+name: Update Premium Core
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version of Clash Premium, such as 2022.05.18'
+        required: true
+        type: string
+env:
+  download_version: ${{ github.event.inputs.version }}
+  download_url: https://release.dreamacro.workers.dev
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone Repository
+      uses: actions/checkout@main
+    - name: Init Dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y upx-ucl
+    - name: Download Core
+      run: |
+        archs="386 amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat"
+        mkdir tmp
+        for arch in ${archs};do
+          wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
+          chmod +x ./tmp/clash-linux-${arch}
+          if [ "${arch}" != "armv5" ];then
+            upx ./tmp/clash-linux-${arch}
+          fi
+        done
+    - name: Update
+      run: |
+        rm -fr ./bin/clashpre/*
+        cp ./tmp/* ./bin/clashpre/
+        rm -fr ./tmp
+        sed -i "s/clashpre_v=.*/clashpre_v=$(./bin/clashpre/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
+    - name: Commit and push
+      run: |
+        git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
+        git add . && git commit -m "更新Premium内核至${download_version}" || exit 0
+        git push
+        

--- a/.github/workflows/update_prenium_core.yaml
+++ b/.github/workflows/update_prenium_core.yaml
@@ -16,11 +16,11 @@ jobs:
     - name: Clone Repository
       uses: actions/checkout@main
     - name: Init Dependencies
-      env:
-        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update
-        sudo apt-get install -y upx-ucl
+        wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+        wget https://github.com/upx/upx/releases/download/v3.93/upx-3.93-amd64_linux.tar.xz
+        tar xf upx-3.96-amd64_linux.tar.xz
+        tar xf upx-3.93-amd64_linux.tar.xz
     - name: Download Core
       run: |
         archs="386 amd64 armv5 armv7 armv8 mips-softfloat mipsle-hardfloat mipsle-softfloat"
@@ -29,9 +29,14 @@ jobs:
           wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
           chmod +x ./tmp/clash-linux-${arch}
           if [ "${arch}" != "armv5" ];then
-            upx ./tmp/clash-linux-${arch}
+            if [ "${arch}" = "mips-softfloat" ];then
+              ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${arch}
+            else
+              ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${arch}
+            fi
           fi
         done
+        rm -fr upx*
     - name: Update
       run: |
         rm -fr ./bin/clashpre/*

--- a/.github/workflows/update_prenium_core.yaml
+++ b/.github/workflows/update_prenium_core.yaml
@@ -29,7 +29,7 @@ jobs:
           wget "${download_url}/${download_version}/clash-linux-${arch}-${download_version}.gz" -O - | gunzip -c > ./tmp/clash-linux-${arch}
           chmod +x ./tmp/clash-linux-${arch}
           if [ "${arch}" != "armv5" ];then
-            if [ "${arch}" = "mips-softfloat" ];then
+            if [[ ${arch} == mips* ]];then
               ./upx-3.93-amd64_linux/upx ./tmp/clash-linux-${arch}
             else
               ./upx-3.96-amd64_linux/upx ./tmp/clash-linux-${arch}


### PR DESCRIPTION
- GitHub Actions Workflows 在外网环境，没必要使用 cdn，反而容易造成获取的内容不是最新
- 添加4个 workflow 用于更新 Clash 内核，输入 tag 并启动即可自动完成更新内核、upx 压缩、以及刷新版本信息

![image](https://user-images.githubusercontent.com/68163551/171643128-81c2c29c-b500-4bea-8d6a-aa952b7bbd09.png)
