### PR TITLE
小米设备软固化 SSH 时备份还原 authorized_keys

### DIFF
--- a/scripts/clash.sh
+++ b/scripts/clash.sh
@@ -1321,6 +1321,7 @@ tools(){
 				read -p "请输入需要还原的SSH密码(不影响当前密码,回车可跳过) > " mi_autoSSH_pwd
 				mi_autoSSH=已启用
 				cp -f /etc/dropbear/dropbear_rsa_host_key $clashdir/dropbear_rsa_host_key 2>/dev/null
+				cp -f /etc/dropbear/authorized_keys $clashdir/authorized_keys 2>/dev/null
 				echo -e "\033[32m设置成功！\033[0m"
 				sleep 1
 			else

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -133,6 +133,7 @@ autoSSH(){
 	}
 	#备份还原SSH秘钥
 	[ -f $clashdir/dropbear_rsa_host_key ] && ln -sf $clashdir/dropbear_rsa_host_key /etc/dropbear/dropbear_rsa_host_key
+	[ -f $clashdir/authorized_keys ] && ln -sf $clashdir/authorized_keys /etc/dropbear/authorized_keys
 }
 host_lan(){
 	[ -n "$(echo $host | grep -oE "([0-9]{1,3}[\.]){3}[0-9]{1,3}" )" ] && host_lan="$(echo $host | grep -oE "([0-9]{1,3}[\.]){3}")0/24"


### PR DESCRIPTION
备份还原 authorized_keys 便于登录