### PR TITLE
modify_yaml="已开启"时才强制覆盖配置文件

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -918,7 +918,7 @@ start)
 		bfstart
 		stop_iptables #清理iptables
 		#使用内置规则强行覆盖config配置文件
-		[ "$modify_yaml" != "已开启" ] && modify_yaml
+		[ "$modify_yaml" = "已开启" ] && modify_yaml
 		#使用不同方式启动clash服务
 		if [ "$start_old" = "已开启" ];then
 			start_old


### PR DESCRIPTION
在最近的使用中需要固定dns的解析地址，但修改配置文件后总是被覆盖，于是看了下代码。默认不更改配置的情况下`modify_yaml="未开启"`，但实际使用时却覆盖了配置文件。这里感觉`modify_yaml`应该等于“已开启”时才需要强制覆盖吧