### PR TITLE
Closes #63 订阅链接中的'%26'会被解析为‘&’致使导入配置文件失败

### DIFF
--- a/scripts/getdate.sh
+++ b/scripts/getdate.sh
@@ -106,6 +106,11 @@ getyaml(){
 		fi
 	fi
 }
+urlencode() {
+    local data
+    data="$(curl -s -o /dev/null -w %{url_effective} --get --data-urlencode "$1" "")"
+    echo "${data##/?}"
+}
 getlink(){
 	echo -----------------------------------------------
 	echo -e "\033[30;47m 欢迎使用在线生成配置文件功能！\033[0m"
@@ -133,7 +138,7 @@ getlink(){
 		link=`echo ${link/\ \(*\)/''}`   #删除恶心的超链接内容
 		link=`echo ${link/*\&url\=/""}`   #将clash完整链接还原成单一链接
 		link=`echo ${link/\&config\=*/""}`   #将clash完整链接还原成单一链接
-		link=`echo ${link//\&/\%26}`   #将分隔符 & 替换成urlcode：%26
+		link=`echo $(urlencode $link)`   #URL编码
 		if [ -n "$test" ];then
 			if [ -z "$Url_link" ];then
 				Url_link="$link"
@@ -194,7 +199,7 @@ getlink2(){
 	read -p "请输入完整链接 > " link
 	test=$(echo $link | grep -iE "tp.*://" )
 	link=`echo ${link/\ \(*\)/''}`   #删除恶心的超链接内容
-	link=`echo ${link//\&/\%26}`   #将分隔符 & 替换成urlcode：%26
+	link=`echo $(urlencode $link)`   #URL编码
 	if [ -n "$link" -a -n "$test" ];then
 		echo -----------------------------------------------
 		echo -e 请检查输入的链接是否正确：

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -139,6 +139,9 @@ host_lan(){
 	[ -n "$(echo $host | grep -oE "([0-9]{1,3}[\.]){3}[0-9]{1,3}" )" ] && host_lan="$(echo $host | grep -oE "([0-9]{1,3}[\.]){3}")0/24"
 }
 #配置文件相关
+urldecode() {
+  printf -v REPLY '%b' "${1//%/\\x}"
+}
 getyaml(){
 	[ -z "$rule_link" ] && rule_link=1
 	[ -z "$server_link" ] && server_link=1
@@ -169,7 +172,7 @@ https://github.com/juewuy/ShellClash/raw/master/rules/ACL4SSR_Online_Games.ini
 https://github.com/juewuy/ShellClash/raw/master/rules/ACL4SSR_Online_Mini_Games.ini
 https://github.com/juewuy/ShellClash/raw/master/rules/ACL4SSR_Online_Full_Games.ini
 EOF`
-	Https=$(echo ${Https//\%26/\&})   #将%26替换回&
+	Https=$(echo $(urldecode $Https ))  #URL解码
 	#如果传来的是Url链接则合成Https链接，否则直接使用Https链接
 	if [ -z "$Https" ];then
 		[ -n "$(echo $Url | grep -o 'vless')" ] && Server='https://sub.shellclash.cf'


### PR DESCRIPTION
将 & 转义的时候一同对其它字符都做一次 url encode，以解决 #63 中提到的问题。