### PR TITLE
Update misnap_init.sh

### DIFF
--- a/scripts/misnap_init.sh
+++ b/scripts/misnap_init.sh
@@ -4,21 +4,27 @@
 clashdir=/data/clash
 profile=/etc/profile
 
-#h初始化环境变量
-sed -i "/alias clash/d" $profile 
-sed -i "/export clashdir/d" $profile 
-echo "alias clash=\"$clashdir/clash.sh\"" >> $profile 
-echo "export clashdir=\"$clashdir\"" >> $profile 
-#设置init.d服务并启动clash服务
-ln -sf $clashdir/clashservice /etc/init.d/clash
-chmod 755 /etc/init.d/clash
+#检查clash运行状态
+if [ -z $(pidof clash) ]; then
+	#初始化环境变量
+	sed -i "/alias clash/d" $profile
+	sed -i "/export clashdir/d" $profile
+	echo "alias clash=\"$clashdir/clash.sh\"" >>$profile
+	echo "export clashdir=\"$clashdir\"" >>$profile
+	#设置init.d服务并启动clash服务
+	ln -sf $clashdir/clashservice /etc/init.d/clash
+	chmod 755 /etc/init.d/clash
 
-if [ ! -f $clashdir/.dis_startup ];then
-	log_file=`uci get system.@system[0].log_file`
-	while [ "$i" -lt 10 ];do
-		sleep 5
-		[ -n "$(grep 'init complete' $log_file)" ] && i=10 || i=$((i+1))
-	done
-	/etc/init.d/clash start
-	/etc/init.d/clash enable
+	if [ ! -f $clashdir/.dis_startup ]; then
+		log_file=$(uci get system.@system[0].log_file)
+		while [ "$i" -lt 10 ]; do
+			sleep 5
+			[ -n "$(grep 'init complete' $log_file)" ] && i=10 || i=$((i + 1))
+		done
+		/etc/init.d/clash start
+		/etc/init.d/clash enable
+	fi
+else
+	#重启clash
+	$clashdir/start.sh start
 fi


### PR DESCRIPTION
启动防火墙时，先检查clash运行状态，避免多实例。