### PR TITLE
清除防火墙ipv6 dns规则时，先清除相关引用

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -949,6 +949,7 @@ stop_firewall(){
 		ip6tables -t nat -F clashv6 2> /dev/null
 		ip6tables -t nat -X clashv6 2> /dev/null
 		#dns
+		ip6tables -t nat -D PREROUTING -p udp --dport 53 -j clashv6_dns 2>/dev/null
 		ip6tables -t nat -F clashv6_dns 2> /dev/null
 		ip6tables -t nat -X clashv6_dns 2> /dev/null
 		#tun


### PR DESCRIPTION
添加清除clashv6_dns链相关引用的命令，作者应该是写的时候忘了