### PR TITLE
调整工作流脚本中 git clone 及 push 的方式；新增自动清理旧的工作流

### DIFF
--- a/.github/workflows/bin_update.yml
+++ b/.github/workflows/bin_update.yml
@@ -20,8 +20,10 @@ jobs:
 
     steps:
     
-    - name: Checkout
-      uses: actions/checkout@master
+    - uses: actions/checkout@v3
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        persist-credentials: true
  
     - name: Apt Update
       env:
@@ -95,12 +97,17 @@ jobs:
         echo GeoIP_v=`date '+%Y%m%d'` >> version
         echo IP数据库及根证书文件更新完成！
 
-    - name: Commit and push
+    - name: Git Commit
       run: |
         git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
         git add . && git commit -m "自动更新最新Dashboard、地址库、根证书" || exit 0
-        git push
-        
+
+    - name: Git Push
+      uses: ad-m/github-push-action@master
+      with:
+        ssh: true
+        branch: ${{ github.ref }}
+
     - name: Cleanup Workflow
       uses: Mattraks/delete-workflow-runs@main
       with:

--- a/.github/workflows/update_clash_core.yaml
+++ b/.github/workflows/update_clash_core.yaml
@@ -13,8 +13,10 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone Repository
-      uses: actions/checkout@main
+    - uses: actions/checkout@v3
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        persist-credentials: true
     - name: Init Dependencies
       run: |
         wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
@@ -43,9 +45,17 @@ jobs:
         cp ./tmp/* ./bin/clash/
         rm -fr ./tmp
         sed -i "s/clash_v=.*/clash_v=$(./bin/clash/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-    - name: Commit and push
+    - name: Git Commit
       run: |
         git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
         git add . && git commit -m "更新Clash内核至${download_version}" || exit 0
-        git push
-        
+    - name: Git Push
+      uses: ad-m/github-push-action@master
+      with:
+        ssh: true
+        branch: ${{ github.ref }}
+    - name: Cleanup Workflow
+      uses: Mattraks/delete-workflow-runs@main
+      with:
+        retain_days: 1
+        keep_minimum_runs: 3

--- a/.github/workflows/update_dotnet_core.yaml
+++ b/.github/workflows/update_dotnet_core.yaml
@@ -13,8 +13,10 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone Repository
-      uses: actions/checkout@main
+    - uses: actions/checkout@v3
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        persist-credentials: true
     - name: Init Dependencies
       run: |
         wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
@@ -43,9 +45,18 @@ jobs:
         cp ./tmp/* ./bin/clash.net/
         rm -fr ./tmp
         sed -i "s/clashnet_v=.*/clashnet_v=$(./bin/clash.net/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-    - name: Commit and push
+    - name: Git Commit
       run: |
         git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
         git add . && git commit -m "更新DotNet内核至${download_version}" || exit 0
         git push
-        
+    - name: Git Push
+      uses: ad-m/github-push-action@master
+      with:
+        ssh: true
+        branch: ${{ github.ref }}
+    - name: Cleanup Workflow
+      uses: Mattraks/delete-workflow-runs@main
+      with:
+        retain_days: 1
+        keep_minimum_runs: 3

--- a/.github/workflows/update_meta_core.yaml
+++ b/.github/workflows/update_meta_core.yaml
@@ -14,8 +14,10 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone Repository
-      uses: actions/checkout@main
+    - uses: actions/checkout@v3
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        persist-credentials: true
     - name: Init Dependencies
       run: |
         wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
@@ -51,9 +53,17 @@ jobs:
         cp ./tmp/* ./bin/clash.meta/
         rm -fr ./tmp
         sed -i "s/meta_v=.*/meta_v=$(./bin/clash.meta/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-    - name: Commit and push
+    - name: Git Commit
       run: |
         git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
         git add . && git commit -m "更新Meta内核至${download_version}" || exit 0
-        git push
-        
+    - name: Git Push
+      uses: ad-m/github-push-action@master
+      with:
+        ssh: true
+        branch: ${{ github.ref }}
+    - name: Cleanup Workflow
+      uses: Mattraks/delete-workflow-runs@main
+      with:
+        retain_days: 1
+        keep_minimum_runs: 3

--- a/.github/workflows/update_premium_core.yaml
+++ b/.github/workflows/update_premium_core.yaml
@@ -13,8 +13,10 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone Repository
-      uses: actions/checkout@main
+    - uses: actions/checkout@v3
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        persist-credentials: true
     - name: Init Dependencies
       run: |
         wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
@@ -44,9 +46,17 @@ jobs:
         cp ./tmp/* ./bin/clashpre/
         rm -fr ./tmp
         sed -i "s/clashpre_v=.*/clashpre_v=$(./bin/clashpre/clash-linux-amd64 -v 2>/dev/null | sed 's/ linux.*//;s/.* //')/" bin/version
-    - name: Commit and push
+    - name: Git Commit
       run: |
         git config --global user.email "juewuy@gmail.com" && git config --global user.name "Bot"
         git add . && git commit -m "更新Premium内核至${download_version}" || exit 0
-        git push
-        
+    - name: Git Push
+      uses: ad-m/github-push-action@master
+      with:
+        ssh: true
+        branch: ${{ github.ref }}
+    - name: Cleanup Workflow
+      uses: Mattraks/delete-workflow-runs@main
+      with:
+        retain_days: 1
+        keep_minimum_runs: 3


### PR DESCRIPTION
Actions 工作流中直接执行 `git push` 的方式推送更新已不可用，改用插件使用 SSH 的方式推送。需要在 `Settings` - `Secrets and variables` - `Actions` 中新建名为 SSH_PRIVATE_KEY 的 secret，并填入自己的 GitHub SSH 私钥。