### PR TITLE
Revert "修复PID判断不精准导致获取运行状态出错的问题"

### DIFF
--- a/scripts/clash.sh
+++ b/scripts/clash.sh
@@ -63,7 +63,7 @@ ckstatus(){
 		auto1="\033[36m允许\033[0mclash开机启动"
 	fi
 	#获取运行状态
-	PID=$(pidof $clashdir/clash)
+	PID=$(pidof clash)
 	if [ -n "$PID" ];then
 		run="\033[32m正在运行（$redir_mod）\033[0m"
 		VmRSS=`cat /proc/$PID/status|grep -w VmRSS|awk '{print $2,$3}'`
@@ -178,7 +178,7 @@ clashstart(){
 	echo -----------------------------------------------
 	$clashdir/start.sh start
 	sleep 1
-	[ -n "$(pidof $clashdir/clash)" ] && startover
+	[ -n "$(pidof clash)" ] && startover
 }
 checkrestart(){
 	echo -----------------------------------------------
@@ -1286,7 +1286,7 @@ clashcfg(){
 			setconfig common_ports $common_ports
 		}
 		echo -----------------------------------------------
-		if [ -n "$(pidof $clashdir/clash)" ];then
+		if [ -n "$(pidof clash)" ];then
 			read -p "切换时将停止clash服务，是否继续？(1/0) > " res
 			[ "$res" = 1 ] && $clashdir/start.sh stop && set_common_ports
 		else
@@ -1486,7 +1486,7 @@ EOF
 	;;
 	8)
 		source $CFG_PATH
-		if [ -n "$(pidof $clashdir/clash)" ];then
+		if [ -n "$(pidof clash)" ];then
 			echo -----------------------------------------------
 			echo -e "\033[33m检测到clash服务正在运行，需要先停止clash服务！\033[0m"
 			read -p "是否停止clash服务？(1/0) > " res

--- a/scripts/misnap_init.sh
+++ b/scripts/misnap_init.sh
@@ -63,7 +63,7 @@ case "$1" in
 	tunfix) tunfix ;;
 	init) init ;;
 	*)
-		if [ -z $(pidof $clashdir/clash) ];then
+		if [ -z $(pidof clash) ];then
 			init
 		else
 			sleep 10

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -57,7 +57,7 @@ logger(){
 	[ -z "$3" ] && {
 		getconfig
 		[ -n "$device_name" ] && log_text="$log_text($device_name)"
-		[ -n "$(pidof $clashdir/clash)" ] && {
+		[ -n "$(pidof clash)" ] && {
 			[ -n "$authentication" ] && auth="$authentication@"
 			export https_proxy="http://${auth}127.0.0.1:$mix_port"
 		}
@@ -1251,7 +1251,7 @@ afstart(){
 		#加载定时任务
 		[ -f $clashdir/cron ] && croncmd $clashdir/cron	
 		#启用面板配置自动保存
-		cronset '#每10分钟保存节点配置' "*/10 * * * * test -n \"\$(pidof $clashdir/clash)\" && $clashdir/start.sh web_save #每10分钟保存节点配置"
+		cronset '#每10分钟保存节点配置' "*/10 * * * * test -n \"\$(pidof clash)\" && $clashdir/start.sh web_save #每10分钟保存节点配置"
 		[ -f $clashdir/web_save ] && web_restore & #后台还原面板配置
 		#推送日志
 		{ sleep 30;logger Clash服务已启动！;} &
@@ -1283,7 +1283,7 @@ afstart)
 		afstart
 	;;
 start)		
-		[ -n "$(pidof $clashdir/clash)" ] && $0 stop #禁止多实例
+		[ -n "$(pidof clash)" ] && $0 stop #禁止多实例
 		getconfig
 		#检测必须文件并下载
 		bfstart
@@ -1304,7 +1304,7 @@ start)
 stop)	
 		getconfig
 		logger Clash服务即将关闭……
-		[ -n "$(pidof $clashdir/clash)" ] && [ "$restore" = false ] && web_save #保存面板配置
+		[ -n "$(pidof clash)" ] && [ "$restore" = false ] && web_save #保存面板配置
 		#删除守护进程&面板配置自动保存
 		cronset "clash保守模式守护进程"
 		cronset "保存节点配置"
@@ -1315,7 +1315,7 @@ stop)
 		elif [ "$USER" = "root" ];then
 			systemctl stop clash.service >/dev/null 2>&1
 		fi
-		PID=$(pidof $clashdir/clash) && [ -n "$PID" ] &&  kill -9 $PID >/dev/null 2>&1
+		PID=$(pidof clash) && [ -n "$PID" ] &&  kill -9 $PID >/dev/null 2>&1
 		stop_firewall #清理路由策略
 		$0 unset_proxy #禁用本机代理
         ;;
@@ -1367,7 +1367,7 @@ logger)
 	;;
 webget)
 		#设置临时代理 
-		if [ -n "$(pidof $clashdir/clash)" ];then
+		if [ -n "$(pidof clash)" ];then
 			getconfig
 			[ -n "$authentication" ] && auth="$authentication@"
 			export https_proxy="http://${auth}127.0.0.1:$mix_port"
@@ -1413,7 +1413,7 @@ web_restore)
 	;;
 daemon)
 		getconfig
-		cronset '#clash保守模式守护进程' "*/1 * * * * test -z \"\$(pidof $clashdir/clash)\" && $clashdir/start.sh restart #clash保守模式守护进程"
+		cronset '#clash保守模式守护进程' "*/1 * * * * test -z \"\$(pidof clash)\" && $clashdir/start.sh restart #clash保守模式守护进程"
 	;;
 cronset)
 		cronset $2 $3


### PR DESCRIPTION
Reverts juewuy/ShellClash#378

部分设备不支持这样的写法，先回退了，我再想想办法：

```
root@XiaoQiang:~# pidof /data/clash/clash
root@XiaoQiang:~# pidof clash
19440
```
