### PR TITLE
修复小米设备开机初始化完成的判断

### DIFF
--- a/scripts/clashservice
+++ b/scripts/clashservice
@@ -5,11 +5,28 @@ START=99
 SERVICE_DAEMONIZE=1
 SERVICE_WRITE_PID=1
 USE_PROCD=1
+EXTRA_COMMANDS="start_in_procd"
 #获取目录
 DIR=$(cat /etc/profile | grep clashdir | awk -F "\"" '{print $2}')
 [ -z "$DIR" ] && DIR=$(cat ~/.bashrc | grep clashdir | awk -F "\"" '{print $2}')
 BINDIR=$(cat $DIR/mark | grep bindir | awk -F "=" '{print $2}')
 [ -z "$BINDIR" ] && BINDIR=$DIR
+
+start_in_procd() {
+	# 等待开机初始化完成
+	[ ! -f /tmp/clash_start_time ] && {
+		log_file=$(uci get system.@system[0].log_file)
+		i=0
+		while [ "$i" -lt 60 ]; do
+			[ -n "$(grep 'init complete' $log_file)" ] && break || i=$((i + 1))
+			sleep 1
+		done
+	}
+	#其他设置
+	$DIR/start.sh afstart
+	#启动clash
+	$BINDIR/clash -d $BINDIR
+}
 
 start_service() {
 	#检测必须文件
@@ -20,10 +37,8 @@ start_service() {
 		procd_set_param respawn
 		procd_set_param stderr 0
 		procd_set_param stdout 0
-		procd_set_param command $BINDIR/clash -d $BINDIR
+		procd_set_param command $DIR/clashservice start_in_procd
 		procd_close_instance
-		#其他设置
-		$DIR/start.sh afstart
 	fi
 }
 
@@ -33,9 +48,7 @@ start() {
 		$DIR/start.sh bfstart
 		if [ "$?" = "0" ];then
 			#创建后台进程
-			service_start  $BINDIR/clash -d $BINDIR
-			#其他设置
-			$DIR/start.sh afstart
+			service_start $DIR/clashservice start_in_procd
 			#设置守护进程
 			$DIR/start.sh daemon
 		fi

--- a/scripts/misnap_init.sh
+++ b/scripts/misnap_init.sh
@@ -46,15 +46,8 @@ init(){
 	chmod 755 /etc/init.d/clash
 	#启动服务
 	if [ ! -f $clashdir/.dis_startup ]; then
-		log_file=$(uci get system.@system[0].log_file)
-		while [ "$i" -lt 10 ]; do
-			sleep 5
-			[ -n "$(grep 'init complete' $log_file)" ] && i=10 || i=$((i + 1))
-		done
 		#AX6S/AX6000修复tun功能
 		[ -f $clashdir/tun.ko -a ! -f /lib/modules/4.4.198/tun.ko ] && tunfix
-		#启动延迟
-		sleep 60
 		#启动服务
 		/etc/init.d/clash start
 		/etc/init.d/clash enable


### PR DESCRIPTION
大佬您好，我发现 `misnap_init.sh` 中对系统初始化完成的判断没有起到什么作用，而且因为脚本同步运行实际上还会阻塞系统初始化导致启动时间变长。我将系统初始化完成的判断放在 procd 进程中进行，这样既不会阻塞系统初始化的进程，路由器的启动时间也缩短了。在红米AX6s测试效果很好，不需要设置启动延迟，也没有遇到 Tun 不生效的问题了。