### PR TITLE
修复 自定义proxy-providers 多次重启导致 proxy-providers key重复的问题

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -334,7 +334,7 @@ modify_yaml(){
 	[ -z "$mode" ] && mode='Rule'
 	#分割配置文件
 	mkdir -p $tmpdir > /dev/null
-	yaml_p=$(grep -n "^prox" $yaml | head -1 | cut -d ":" -f 1) #获取节点起始行号
+	yaml_p=$(grep -n "^proxies:" $yaml | head -1 | cut -d ":" -f 1) #获取节点起始行号
 	yaml_r=$(grep -n "^rules:" $yaml | head -1 | cut -d ":" -f 1) #获取规则起始行号
 	if [ "$yaml_p" -lt "$yaml_r" ];then
 		sed -n "${yaml_p},${yaml_r}p" $yaml > $tmpdir/proxy.yaml


### PR DESCRIPTION
在user.yaml 中 自定义 proxy-providers
后续每次重启都会多一个proxy-providers 节点 导致yaml解析错误
按照旧脚本 proxy-providers 会被写入到$tmpdir/proxy.yaml 
导致后续合并的时候重复