### PR TITLE
修复意外加入 bypass 的域名

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -399,8 +399,8 @@ modify_yaml(){
 	#节点绕过功能支持
 	sed -i "/#节点绕过/d" $tmpdir/rules.yaml
 	[ "$proxies_bypass" = "已启用" ] && {
-		cat $tmpdir/proxies.yaml | sed '/^proxy-/,$d' | sed '/^rule-/,$d' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | awk '!a[$0]++' | sed 's/^/\ -\ IP-CIDR,/g' | sed 's|$|/32,DIRECT #节点绕过|g' >> $tmpdir/proxies_bypass
-		cat $tmpdir/proxies.yaml | sed '/^proxy-/,$d' | sed '/^rule-/,$d' | grep -vE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\.?'| awk '!a[$0]++' | sed 's/^/\ -\ DOMAIN,/g' | sed 's/$/,DIRECT #节点绕过/g' >> $tmpdir/proxies_bypass
+		cat $tmpdir/proxies.yaml | sed '/^proxy-/,$d' | sed '/^rule-/,$d' | grep -v '^\s*#' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | awk '!a[$0]++' | sed 's/^/\ -\ IP-CIDR,/g' | sed 's|$|/32,DIRECT #节点绕过|g' >> $tmpdir/proxies_bypass
+		cat $tmpdir/proxies.yaml | sed '/^proxy-/,$d' | sed '/^rule-/,$d' | grep -v '^\s*#' | grep -vE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\.?'| awk '!a[$0]++' | sed 's/^/\ -\ DOMAIN,/g' | sed 's/$/,DIRECT #节点绕过/g' >> $tmpdir/proxies_bypass
 		cat $tmpdir/rules.yaml >> $tmpdir/proxies_bypass 
 		mv -f $tmpdir/proxies_bypass $tmpdir/rules.yaml
 	}


### PR DESCRIPTION
启用 `proxies_bypass` 时, 如果注释中包含域名，则会意外加入 `DIRECT` 规则。最典型的是 `github.com`，因为很多注释带 github 仓库地址。

例子：
```
❯ cat /tmp/proxies.yaml
# 支持的协议及加密算法示例请查阅 Clash 项目 README 以使用最新格式：https://github.com/Dreamacro/clash/blob/master/README.md

# Shadowsocks 支持的加密方式:
#   aes-128-gcm aes-192-gcm aes-256-gcm
#   aes-128-cfb aes-192-cfb aes-256-cfb
#   aes-128-ctr aes-192-ctr aes-256-ctr
#   rc4-md5 chacha20-ietf xchacha20
#   chacha20-ietf-poly1305 xchacha20-ietf-poly1305

- name: "ssh2-remote@lan"
  type: socks5
  server: 192.168.5.111
  port: 1081

# 代理组策略
# 策略组示例请查阅 Clash 项目 README 以使用最新格式：https://github.com/Dreamacro/clash/blob/master/README.md
```

意外加入的域名：

```
❯ cat /tmp/proxies.yaml | sed '/^proxy-/,$d' | sed '/^rule-/,$d' | grep -vE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\.?'
github.com
README.md
github.com
README.md
```

@juewuy 