### PR TITLE
Update servers.list

### DIFF
--- a/public/servers.list
+++ b/public/servers.list
@@ -30,3 +30,4 @@
 508 洞主规则重度完整版 https://gist.githubusercontent.com/tindy2013/1fa08640a9088ac8652dbd40c5d2715b/raw/lhie1_dler.ini  
 509 Acl4SSR多国精简 https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/config/ACL4SSR_Online_Mini_MultiCountry.ini 
 510 Acl4SSR回国专用 https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/config/ACL4SSR_BackCN.ini  
+511 Acl4SSR增强国外GFW https://raw.githubusercontent.com/ACL4SSR/ACL4SSR/master/Clash/config/ACL4SSR_WithGFW.ini (适合黑名单模式使用)


### PR DESCRIPTION
ACL4SSR规则的增强国外规则版本，适合黑名单模式（即将match设为direct）使用，避免对多余网站进行代理