### PR TITLE
更新 web_save 适配 clash meta 1.5.1 报文格式

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1043,7 +1043,7 @@ stop_firewall(){
 #面板配置保存相关
 web_save(){
 	#使用get_save获取面板节点设置
-	get_save http://127.0.0.1:${db_port}/proxies | awk -F ':\\{"' '{for(i=1;i<=NF;i++) print $i}' | grep -aE '^all".*"Selector"' > $TMPDIR/clash_web_check_$USER
+	get_save http://127.0.0.1:${db_port}/proxies | awk -F ':\\{"' '{for(i=1;i<=NF;i++) print $i}' | grep -aE '(^all|^alive)".*"Selector"' > $TMPDIR/clash_web_check_$USER
 	while read line ;do
 		def=$(echo $line | awk -F "[[,]" '{print $2}')
 		now=$(echo $line | grep -oE '"now".*",' | sed 's/"now"://g' | sed 's/"type":.*//g' |  sed 's/,//g')


### PR DESCRIPTION
Clash.Meta 1.5.1 通过 web_save 持久化当前选择的节点没效果，对比 JSON 报文发现 type 为 Selector 的部分多了个 alive 字段，不再以 all 字段开头，如下图：

![屏幕截图 2023-08-26 153906](https://github.com/juewuy/ShellClash/assets/68163551/21acc201-00a9-4c78-aebc-dd2f3773897c)
![屏幕截图 2023-08-26 153917](https://github.com/juewuy/ShellClash/assets/68163551/4c4f61ef-5a99-45cc-9919-7520fea39f00)
