### PR TITLE
Update fake_ip_filter.list

### DIFF
--- a/public/fake_ip_filter.list
+++ b/public/fake_ip_filter.list
@@ -134,6 +134,7 @@ Mijia Cloud
 +.cmbimg.com
 #AdGuard
 local.adguard.org
+static.adtidy.org
 #迅雷
 +.sandai.net
 +.n0808.com


### PR DESCRIPTION
添加 `static.adtidy.org` 域名，该域名是 AdGuardHome 检查更新地址。可防止 AdGuardHome 作为下游与 ShellClash（fake-ip 模式）搭配时，AdGuardHome 面板提示检查更新失败的问题