### PR TITLE
fix: update command to get host ip

### DIFF
--- a/scripts/clash.sh
+++ b/scripts/clash.sh
@@ -670,7 +670,7 @@ setipv6(){
 setfirewall(){
 	set_cust_host_ipv4(){		
 		echo -----------------------------------------------
-		echo -e "当前已自动设置透明路由的网段为: \033[32m$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'br' | grep -v 'iot' | grep -E ' 1(92|0|72)\.' | sed 's/.*inet.//g' | sed 's/br.*$//g' | tr '\n' ' ' && echo ) \033[0m"
+		echo -e "当前已自动设置透明路由的网段为: \033[32m$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'br' | grep -v 'iot' | grep -E ' 1(92|0|72)\.' | awk '{print $2}' | tr '\n' ' ' && echo ) \033[0m"
 		echo -e "当前已添加的自定义网段为:\033[36m$cust_host_ipv4\033[0m"
 		echo -----------------------------------------------	
 		echo -e "\033[33m自定义网段不会覆盖自动获取的网段地址，无需重复添加\033[0m"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -141,7 +141,7 @@ mark_time(){
 getlanip(){
 	i=1
 	while [ "$i" -le "10" ];do
-		host_ipv4=$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'br' | grep -Ev 'iot|metric' | grep -E ' 1(92|0|72)\.' | sed 's/.*inet.//g' | sed 's/br.*$//g' ) #ipv4局域网网段
+		host_ipv4=$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'br' | grep -v 'iot' | grep -E ' 1(92|0|72)\.' | awk '{print $2}' ) #ipv4局域网网段
 		[ "$ipv6_redir" = "已开启" ] && host_ipv6=$(ip a 2>&1 | grep -w 'inet6' | grep -E 'global' | sed 's/.*inet6.//g' | sed 's/scope.*$//g' ) #ipv6公网地址段
 		[ -f  $TMPDIR/ShellClash_log ] && break
 		[ -n "$host_ipv4" -a -n "$host_ipv6" ] && break


### PR DESCRIPTION
#484 
On ubuntu 22.04 `ip a` output could have `metric` field which will cause some host IPs to be filtered.

>1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
>    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
>    inet 127.0.0.1/8 scope host lo
>       valid_lft forever preferred_lft forever
>    inet6 ::1/128 scope host
>       valid_lft forever preferred_lft forever
>2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
>    link/ether b8:27:eb:24:1f:eb brd ff:ff:ff:ff:ff:ff
>    inet 192.168.50.114/24 **metric 100** brd 192.168.50.255 scope global dynamic eth0
>       valid_lft 78689sec preferred_lft 78689sec
>    inet6 fdad:1cb3:1588:4e45:ba27:ebff:fe24:1feb/64 scope global dynamic mngtmpaddr noprefixroute
>       valid_lft 1707sec preferred_lft 1707sec
>    inet6 fe80::ba27:ebff:fe24:1feb/64 scope link
>       valid_lft forever preferred_lft forever
>3: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
>    link/ether b8:27:eb:71:4a:be brd ff:ff:ff:ff:ff:ff
>    inet 192.168.50.152/24 **metric 600** brd 192.168.50.255 scope global dynamic wlan0
>       valid_lft 81395sec preferred_lft 81395sec
>    inet6 fdad:1cb3:1588:4e45:ba27:ebff:fe71:4abe/64 scope global dynamic mngtmpaddr noprefixroute
>       valid_lft 1707sec preferred_lft 1707sec
>    inet6 fe80::ba27:ebff:fe71:4abe/64 scope link
>       valid_lft forever preferred_lft forever
>4: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
>    link/ether 02:42:ea:aa:c5:ba brd ff:ff:ff:ff:ff:ff
>    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
>       valid_lft forever preferred_lft forever

So I changed `grep -Ev 'iot|metric'` statement to avoid avoid filtering rows containing `metric`.
And use `awk '{print $2}'` instead of `sed 's/br.*$//g'` to get ip address while avoiding matching patterns containing metric