### PR TITLE
移除切换内核后的检查更新操作

### DIFF
--- a/scripts/webget.sh
+++ b/scripts/webget.sh
@@ -2182,7 +2182,6 @@ update(){
 
 	elif [ "$num" = 2 ]; then
 		setcore
-		update
 
 	elif [ "$num" = 3 ]; then
 		setgeo


### PR DESCRIPTION
下载内核文件成功后会关闭内核进程并且不会自动再启动，使得设备“失联”，在该状态下再检查更新会让脚本卡住