### PR TITLE
feat: 增加 PushDeer 自建服务器支持

### DIFF
--- a/scripts/libs/logger.sh
+++ b/scripts/libs/logger.sh
@@ -27,7 +27,8 @@ logger() {
             web_json_post "$url" "$content" &
         }
         [ -n "$push_Deer" ] && {
-            url="https://api2.pushdeer.com/message/push"
+            url="${push_Deer_url%/}"
+            url="${url:-https://api2.pushdeer.com}/message/push"
             content="{\"pushkey\":\"${push_Deer}\",\"text\":\"$log_text\"}"
             web_json_post "$url" "$content" &
         }

--- a/scripts/menus/8_tools.sh
+++ b/scripts/menus/8_tools.sh
@@ -296,12 +296,48 @@ log_pusher() {
                 read -r -p "请输入对应标号> " res
                 if [ "$res" = 1 ]; then
                     push_Deer=
+                    push_Deer_url=
                     setconfig push_Deer
+                    setconfig push_Deer_url
                 else
                     continue
                 fi
             else
                 # echo -e "\033[33m详细设置指南请参考 https://juewuy.github.io/ \033[0m"
+                comp_box "请选择PushDeer服务器类型：" \
+                    "1) 官方服务器（api2.pushdeer.com）" \
+                    "2) 自建服务器" \
+                    "" \
+                    "0) 返回上级菜单"
+                read -r -p "请输入对应标号> " num
+                case "$num" in
+                0)
+                    continue
+                    ;;
+                2)
+                    comp_box "请输入自建PushDeer服务器地址（不含/message/push）" \
+                        "例如：\033[36mhttps://push.example.com\033[0m"
+                    btm_box "\033[36m请直接输入服务器地址\033[0m" \
+                        "或输入 0 返回上级菜单"
+                    read -r -p "请输入> " url
+                    if [ "$url" = 0 ]; then
+                        continue
+                    elif [ -z "$url" ]; then
+                        msg_alert "\033[31m输入错误，请重新输入！\033[0m"
+                        continue
+                    fi
+                    push_Deer_url=${url%/}
+                    setconfig push_Deer_url "${url%/}"
+                    ;;
+                1)
+                    push_Deer_url=
+                    setconfig push_Deer_url
+                    ;;
+                *)
+                    errornum
+                    continue
+                    ;;
+                esac
                 comp_box "1. 请先前往 \033[32;4mhttp://www.pushdeer.com/official.html\033[0m 扫码安装快应用或下载APP" \
                     "2. 打开快应用/APP，并完成登陆" \
                     "3. \033[33m切换到「设备」标签页，点击右上角的加号，注册当前设备\033[0m" \


### PR DESCRIPTION
## 功能说明
为 PushDeer 日志推送功能增加对自建服务的支持，可以兼容现有配置，允许用户配置自定义 API 地址。

## 改动内容
- **logger.sh**：将硬编码的官方 API 地址改为支持 `push_Deer_url` 配置，未配置时默认使用官方 `api2.pushdeer.com`，并对 URL 尾部斜杠做处理
- **8_tools.sh**：在 PushDeer 设置中增加服务器类型选择（官方 / 自建），选择自建时引导输入服务器地址，关闭 PushDeer 时同时清除 `push_Deer_url`

## 兼容性
- 已有用户的 `push_Deer` 配置保持不变，`push_Deer_url` 为空时自动使用官方地址
- 新用户可选择官方或自建，选择自建时需输入服务器地址（不含 `/message/push`），并自动去除尾部斜杠

## 测试说明
- 官方模式：选择 1) 官方服务器，输入秘钥，验证能收到推送
- 自建模式：选择 2) 自建服务器，输入自建地址和秘钥，验证能收到推送
- 兼容性：仅配置 `push_Deer`、不配置 `push_Deer_url` 时，可正常使用官方 API