### PR TITLE
修复保守模式 ShellCrash 无法崩溃恢复. Fix #1238

### DIFF
--- a/scripts/libs/check_process.sh
+++ b/scripts/libs/check_process.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Copyright (C) Juewuy
+# 进程检测公共函数库
+
+PIDFILE_DIR="/tmp/ShellCrash"
+
+_get_pidfile_path() {
+    echo "$PIDFILE_DIR/$1.pid"
+}
+
+check_crashcore_running() {
+    local PID
+    PID=$(pidof CrashCore 2>/dev/null | awk '{print $NF}')
+    if [ -n "$PID" ]; then
+        echo "$PID"
+        return 0
+    else
+        return 1
+    fi
+}
+
+#$1=PID文件路径
+check_pidfile_process() {
+    local PIDFILE="$1"
+    local PID
+
+    [ ! -f "$PIDFILE" ] && return 1
+
+    PID=$(cat "$PIDFILE" 2>/dev/null)
+
+    [ -z "$PID" ] && return 1
+    [ "$PID" -eq "$PID" ] 2>/dev/null || return 1
+
+    if kill -0 "$PID" 2>/dev/null; then
+        return 0
+    else
+        rm -f "$PIDFILE"
+        return 1
+    fi
+}
+
+#$1=服务名称
+check_daemon_process() {
+    local service_name="$1"
+    local PIDFILE
+
+    case "$service_name" in
+        shellcrash)
+            check_crashcore_running >/dev/null 2>&1
+            return $?
+            ;;
+        *)
+            PIDFILE=$(_get_pidfile_path "$service_name")
+            check_pidfile_process "$PIDFILE"
+            return $?
+            ;;
+    esac
+}
+
+#$1=服务名称,$2="false"表示已知未运行（可选）
+cleanup_daemon_state() {
+    local service_name="$1"
+    local is_not_running="$2"
+    local PIDFILE
+
+    case "$service_name" in
+        shellcrash)
+            PIDFILE=$(_get_pidfile_path "$service_name")
+            if [ "$is_not_running" = "false" ]; then
+                rm -f "$PIDFILE" 2>/dev/null
+            elif ! check_crashcore_running >/dev/null 2>&1; then
+                rm -f "$PIDFILE" 2>/dev/null
+            fi
+            ;;
+        *)
+            PIDFILE=$(_get_pidfile_path "$service_name")
+            if [ "$is_not_running" = "false" ]; then
+                rm -f "$PIDFILE" 2>/dev/null
+            elif ! check_pidfile_process "$PIDFILE"; then
+                rm -f "$PIDFILE" 2>/dev/null
+            fi
+            ;;
+    esac
+}

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -15,6 +15,7 @@ CFG_PATH="$CRASHDIR"/configs/ShellCrash.cfg
 . "$CRASHDIR"/libs/set_config.sh
 . "$CRASHDIR"/libs/check_cmd.sh
 . "$CRASHDIR"/libs/check_autostart.sh
+. "$CRASHDIR"/libs/check_process.sh
 . "$CRASHDIR"/menus/1_start.sh
 . "$CRASHDIR"/menus/running_status.sh
 errornum() {
@@ -69,7 +70,7 @@ ckstatus() { #脚本启动前检查
         auto1="\033[36m允许\033[0mShellCrash开机启动"
     fi
     #获取运行状态
-    PID=$(pidof CrashCore | awk '{print $NF}')
+    PID=$(check_crashcore_running)
     if [ -n "$PID" ]; then
         run="\033[32m正在运行（$redir_mod）\033[0m"
         running_status

--- a/scripts/menus/bot_tg.sh
+++ b/scripts/menus/bot_tg.sh
@@ -4,6 +4,7 @@
 . "$CRASHDIR"/libs/web_json.sh
 . "$CRASHDIR"/libs/set_config.sh
 . "$CRASHDIR"/libs/web_get_lite.sh
+. "$CRASHDIR"/libs/check_process.sh
 . "$CRASHDIR"/menus/running_status.sh
 . "$CRASHDIR"/configs/gateway.cfg
 . "$CRASHDIR"/configs/ShellCrash.cfg
@@ -49,7 +50,7 @@ EOF
 }
 send_menu(){
 	#获取运行状态
-	PID=$(pidof CrashCore | awk '{print $NF}')
+	PID=$(check_crashcore_running)
 	if [ -n "$PID" ]; then
 		run='🟢正在运行'
 		running_status

--- a/scripts/starts/start_legacy_wd.sh
+++ b/scripts/starts/start_legacy_wd.sh
@@ -1,30 +1,33 @@
+#!/bin/sh
+# Copyright (C) Juewuy
 
 [ -z "$CRASHDIR" ] && CRASHDIR=$(cd "$(dirname "$0")"/.. && pwd)
-PIDFILE="/tmp/ShellCrash/$1.pid"
-LOCKDIR="/tmp/ShellCrash/start_$1.lock"
+SERVICE_NAME="$1"
 
-[ -f "$CRASHDIR"/.start_error ] && [ ! -f /tmp/ShellCrash/crash_start_time ] && exit 1 #当启动失败后禁止开机自启动
-mkdir "$LOCKDIR" 2>/dev/null || exit 1
+. "$CRASHDIR"/libs/check_process.sh
 
-if [ -f "$PIDFILE" ]; then
-	PID="$(cat "$PIDFILE")"
-	if [ -n "$PID" ] && [ "$PID" -eq "$PID" ] 2>/dev/null; then
-		if kill -0 "$PID" 2>/dev/null || [ -d "/proc/$PID" ]; then
-			rm -d "$LOCKDIR" 2>/dev/null
-			exit 0
-		fi
-	else
-		rm -f "$PIDFILE"
-	fi
+#当启动失败后禁止开机自启动
+[ -f "$CRASHDIR"/.start_error ] && [ ! -f /tmp/ShellCrash/crash_start_time ] && exit 1
+
+if check_daemon_process "$SERVICE_NAME"; then
+    exit 0
 fi
 
 #如果没有进程则拉起
-if [ "$1" = "shellcrash" ]; then
-	"$CRASHDIR"/start.sh start
-else
-	[ -f "$CRASHDIR/starts/start_legacy.sh" ] && . "$CRASHDIR/starts/start_legacy.sh"
-	killall bot_tg.sh 2>/dev/null
-	start_legacy "$CRASHDIR/menus/bot_tg.sh" "$1"
-fi
+cleanup_daemon_state "$SERVICE_NAME" "false"
 
-rm -d "$LOCKDIR" 2>/dev/null
+if [ "$SERVICE_NAME" = "shellcrash" ]; then
+    if ! "$CRASHDIR"/start.sh start; then
+        [ -f "$CRASHDIR"/libs/logger.sh ] && . "$CRASHDIR"/libs/logger.sh && logger "守护进程：启动 $SERVICE_NAME 失败" 31
+        exit 1
+    fi
+else
+    if [ -f "$CRASHDIR/starts/start_legacy.sh" ]; then
+        . "$CRASHDIR"/starts/start_legacy.sh
+        killall bot_tg.sh 2>/dev/null
+        if ! start_legacy "$CRASHDIR/menus/bot_tg.sh" "$SERVICE_NAME"; then
+            [ -f "$CRASHDIR"/libs/logger.sh ] && . "$CRASHDIR"/libs/logger.sh && logger "守护进程：启动 $SERVICE_NAME 失败" 31
+            exit 1
+        fi
+    fi
+fi


### PR DESCRIPTION
## 故障描述

- 之前的实现会创建一个 `.lock` 目录，守护进程检测到这个目录存在的时候不会拉起进程 （`mkdir` 在目录已存在的时候会错误退出）
- 但是 mihomo 内核崩溃的时候并不会自动删除 lock 目录，导致守护进程永远被绕过

## 解决方案

- 不依赖 lock 目录，这个并不可靠
- 改为 `pidof` 检测方式
- 统一并复用代码，`crash` 命令展示的内核运行状态和守护进程检测内核运行状态的代码抽取出来并复用