### PR TITLE
使用兼容性更强的 `rm -fr` 代替 `rm -d` 删除锁目录

### DIFF
--- a/scripts/starts/start_legacy_wd.sh
+++ b/scripts/starts/start_legacy_wd.sh
@@ -10,7 +10,7 @@ if [ -f "$PIDFILE" ]; then
 	PID="$(cat "$PIDFILE")"
 	if [ -n "$PID" ] && [ "$PID" -eq "$PID" ] 2>/dev/null; then
 		if kill -0 "$PID" 2>/dev/null || [ -d "/proc/$PID" ]; then
-			rm -d "$LOCKDIR" 2>/dev/null
+			rm -fr "$LOCKDIR" 2>/dev/null
 			exit 0
 		fi
 	else
@@ -27,4 +27,4 @@ else
 	start_legacy "$CRASHDIR/menus/bot_tg.sh" "$1"
 fi
 
-rm -d "$LOCKDIR" 2>/dev/null
+rm -fr "$LOCKDIR" 2>/dev/null


### PR DESCRIPTION
Fix #1238

部分路由器，如华硕的 `rm` 命令来自于 `busybox` 而非 `coreutils`，`busybox` 只支持如下参数:

```sh
BusyBox v1.25.1 (2025-11-15 00:39:08 UTC) multi-call binary.

Usage: rm [-irf] FILE...

Remove (unlink) FILEs

        -i      Always prompt before removing
        -f      Never prompt
        -R,-r   Recurse
```

因此采用兼容性更强的 `rm -fr` 代替 `rm -d` 方式删除锁目录