### PR TITLE
检测端口冲突时区分 tcp 和 udp 端口，防止误报

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -62,7 +62,7 @@ checkport() {
 		fi
 
 		if [ "$conflict_found" -eq 0 ]; then
-			conflict_info=$(check_port_with_info "$((redir_port + 1))" tcp)
+			conflict_info=$(check_port_with_info "$((redir_port + 1))" all)
 			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$((redir_port + 1))"
 		fi
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -50,24 +50,24 @@ checkport() {
 		local conflict_port=""
 		local conflict_info=""
 
-		conflict_info=$(check_port_with_info "$mix_port" tcp)
+		conflict_info=$(check_port_with_info "$mix_port")
 		if [ $? -ne 0 ]; then
 			conflict_found=1
 			conflict_port="$mix_port"
 		fi
 
 		if [ "$conflict_found" -eq 0 ]; then
-			conflict_info=$(check_port_with_info "$redir_port" tcp)
+			conflict_info=$(check_port_with_info "$redir_port")
 			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$redir_port"
 		fi
 
 		if [ "$conflict_found" -eq 0 ]; then
-			conflict_info=$(check_port_with_info "$((redir_port + 1))" all)
+			conflict_info=$(check_port_with_info "$((redir_port + 1))")
 			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$((redir_port + 1))"
 		fi
 
 		if [ "$conflict_found" -eq 0 ]; then
-			conflict_info=$(check_port_with_info "$dns_port" all)
+			conflict_info=$(check_port_with_info "$dns_port")
 			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$dns_port"
 		fi
 

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -43,36 +43,47 @@ checkrestart() {
 
 # 检查端口冲突
 checkport() {
+	. "$CRASHDIR"/menus/check_port.sh
+
 	while true; do
-		# Before each round of checks begins, execute netstat only once and cache the results
-		# Avoid calling the system command once for each port
-		current_listening=$(netstat -ntul 2>&1)
+		local conflict_found=0
+		local conflict_port=""
+		local conflict_info=""
 
-		conflict_found=0
+		conflict_info=$(check_port_with_info "$mix_port" tcp)
+		if [ $? -ne 0 ]; then
+			conflict_found=1
+			conflict_port="$mix_port"
+		fi
 
-		for portx in $dns_port $mix_port $redir_port $((redir_port + 1)) $db_port; do
-			# Use `grep` to search within the cached variables instead of re-running `netstat`
-			conflict_line=$(echo "$current_listening" | grep ":$portx ")
-
-			if [ -n "$conflict_line" ]; then
-
-				comp_box "【$portx】：$MENU_PORT_CONFLICT_TITLE" \
-					"\033[0m$(echo "$conflict_line" | head -n 1)\033[0m" \
-					"\033[36m$MENU_PORT_CONFLICT_HINT\033[0m"
-
-				. "$CRASHDIR"/menus/2_settings.sh && set_adv_config
-				. "$CRASHDIR"/libs/get_config.sh
-
-				# Mark conflict and exit the for loop, triggering the while loop to restart the check
-				# This replaces the original recursive call to `checkport`
-				conflict_found=1
-				break
-			fi
-		done
-
-		# If no conflicts are found after the entire for loop completes,
-		# the while loop exits and the function terminates.
 		if [ "$conflict_found" -eq 0 ]; then
+			conflict_info=$(check_port_with_info "$redir_port" tcp)
+			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$redir_port"
+		fi
+
+		if [ "$conflict_found" -eq 0 ]; then
+			conflict_info=$(check_port_with_info "$((redir_port + 1))" tcp)
+			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$((redir_port + 1))"
+		fi
+
+		if [ "$conflict_found" -eq 0 ]; then
+			conflict_info=$(check_port_with_info "$dns_port" all)
+			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$dns_port"
+		fi
+
+		if [ "$conflict_found" -eq 0 ]; then
+			conflict_info=$(check_port_with_info "$db_port" tcp)
+			[ $? -ne 0 ] && conflict_found=1 && conflict_port="$db_port"
+		fi
+
+		if [ "$conflict_found" -eq 1 ]; then
+			comp_box "【$conflict_port】：$MENU_PORT_CONFLICT_TITLE" \
+				"\033[0m$conflict_info\033[0m" \
+				"\033[36m$MENU_PORT_CONFLICT_HINT\033[0m"
+
+			. "$CRASHDIR"/menus/2_settings.sh && set_adv_config
+			. "$CRASHDIR"/libs/get_config.sh
+		else
 			break
 		fi
 	done
@@ -195,17 +206,17 @@ main_menu() {
 	while true; do
 		ckstatus
 
-		btm_box "1) \033[32m$MENU_MAIN_1\033[0m"\
-		"2) \033[36m$MENU_MAIN_2\033[0m"\
-		"3) \033[31m$MENU_MAIN_3\033[0m"\
-		"4) \033[33m$MENU_MAIN_4\033[0m"\
-		"5) \033[32m$MENU_MAIN_5\033[0m"\
-		"6) \033[36m$MENU_MAIN_6\033[0m"\
-		"7) \033[33m$MENU_MAIN_7\033[0m"\
-		"8) $MENU_MAIN_8"\
-		"9) \033[32m$MENU_MAIN_9\033[0m"\
-		""\
-		"0) $MENU_MAIN_0"
+		btm_box "1) \033[32m$MENU_MAIN_1\033[0m" \
+			"2) \033[36m$MENU_MAIN_2\033[0m" \
+			"3) \033[31m$MENU_MAIN_3\033[0m" \
+			"4) \033[33m$MENU_MAIN_4\033[0m" \
+			"5) \033[32m$MENU_MAIN_5\033[0m" \
+			"6) \033[36m$MENU_MAIN_6\033[0m" \
+			"7) \033[33m$MENU_MAIN_7\033[0m" \
+			"8) $MENU_MAIN_8" \
+			"9) \033[32m$MENU_MAIN_9\033[0m" \
+			"" \
+			"0) $MENU_MAIN_0"
 		read -r -p "$MENU_MAIN_PROMPT" num
 
 		case "$num" in

--- a/scripts/menus/2_settings.sh
+++ b/scripts/menus/2_settings.sh
@@ -393,14 +393,26 @@ inputport() {
 	line_break
 	read -r -p "$INPUT_PORT（1～65535）> " portx
 	. "$CRASHDIR"/menus/check_port.sh
-	if check_port "$portx" "$protocol"; then
-		setconfig "$xport" "$portx"
-		msg_alert "\033[32m$COMMON_SUCCESS\033[0m"
-		return 0
-	else
+
+	if ! check_port "$portx" "$protocol"; then
 		msg_alert "\033[31m$COMMON_FAILED\033[0m"
 		return 1
 	fi
+
+	local ports_to_check=""
+	[ "$xport" != "mix_port" ] && ports_to_check="$ports_to_check|$mix_port"
+	[ "$xport" != "redir_port" ] && ports_to_check="$ports_to_check|$redir_port"
+	[ "$xport" != "dns_port" ] && ports_to_check="$ports_to_check|$dns_port"
+	[ "$xport" != "db_port" ] && ports_to_check="$ports_to_check|$db_port"
+
+	if echo "$ports_to_check|" | grep -q "|$portx|"; then
+		msg_alert "\033[31m$CHECK_PORT_DUP_ERR\033[0m"
+		return 1
+	fi
+
+	setconfig "$xport" "$portx"
+	msg_alert "\033[32m$COMMON_SUCCESS\033[0m"
+	return 0
 }
 
 # 端口设置

--- a/scripts/menus/2_settings.sh
+++ b/scripts/menus/2_settings.sh
@@ -8,673 +8,674 @@ load_lang 2_settings
 
 # 功能设置
 settings() {
-    while true; do
-        # 获取设置默认显示
-        [ -z "$skip_cert" ] && skip_cert=ON
-        [ -z "$sniffer" ] && {
-            sniffer=OFF
-            echo "$crashcore" | grep -q 'singbox' && sniffer=ON
-        }
-        [ -z "$dns_mod" ] && dns_mod='redir_host'
+	while true; do
+		# 获取设置默认显示
+		[ -z "$skip_cert" ] && skip_cert=ON
+		[ -z "$sniffer" ] && {
+			sniffer=OFF
+			echo "$crashcore" | grep -q 'singbox' && sniffer=ON
+		}
+		[ -z "$dns_mod" ] && dns_mod='redir_host'
 
-        comp_box "\033[30;47m$SET_MENU_TITLE\033[0m"
-        content_line "1) $SET_MENU_REDIR\t\033[36m$redir_mod$MENU_MOD\033[0m"
-        content_line "2) $SET_MENU_DNS\t\033[36m$dns_mod\033[0m"
-        content_line "3) $SET_MENU_FW_FILTER"
-        [ "$disoverride" != "1" ] && {
-            content_line "4) $SET_MENU_SKIP_CERT\t\033[36m$skip_cert\033[0m"
-            content_line "5) $SET_MENU_SNIFFER\t\033[36m$sniffer\033[0m"
-            content_line "6) $SET_MENU_ADV_PORT"
-        }
-        content_line "7) $SET_MENU_IPV6\t\033[36m$ipv6_redir\033[0m"
-        btm_box "" \
-            "a) \033[31m$SET_MENU_RESET\033[0m" \
-            "b) \033[36m$SET_MENU_LANG\033[0m" \
-            "c) \033[33m$SET_MENU_UI\033[0m" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ "$USER" != root ] && [ "$USER" != admin ]; then
-                comp_box "$SET_WARN_NONROOT"
-                btm_box "1) $SET_YES" \
-                    "0) $SET_NO_BACK"
-                read -r -p "$COMMON_INPUT> " res
-                if [ "$res" = 1 ]; then
-                    set_redir_mod
-                else
-                    continue
-                fi
-            else
-                set_redir_mod
-            fi
-            ;;
-        2)
-            . "$CRASHDIR"/menus/dns.sh && set_dns_mod
-            ;;
-        3)
-            . "$CRASHDIR"/menus/fw_filter.sh && set_fw_filter
-            ;;
-        4)
-            line_break
-            separator_line "="
-            if [ "$skip_cert" = "OFF" ]; then
-                content_line "$SET_SKIP_CERT_NOW\033[33m$SET_DISABLED\033[0m$SET_SKIP_CERT_ENABLE_Q"
-            else
-                content_line "$SET_SKIP_CERT_NOW\033[33m$SET_ENABLED\033[0m$SET_SKIP_CERT_DISABLE_Q"
-            fi
-            separator_line "="
-            btm_box "1) $SET_YES" \
-                "0) $SET_NO_BACK"
-            read -r -p "$COMMON_INPUT> " num
-            if [ "$num" = 1 ]; then
-                if [ "$skip_cert" = OFF ]; then
-                    skip_cert=ON
-                    msg_alert "\033[33m$SET_SKIP_CERT_ON\033[0m"
-                else
-                    skip_cert=OFF
-                    msg_alert "\033[33m$SET_SKIP_CERT_OFF\033[0m"
-                fi
-                setconfig skip_cert $skip_cert
-            else
-                continue
-            fi
-            ;;
-        5)
-            if [ "$sniffer" = "OFF" ]; then
-                comp_box "$SET_SNIFFER_NOW\033[33m$SET_DISABLED\033[0m$SET_SNIFFER_ENABLE_Q"
-                btm_box "1) $SET_YES" \
-                    "0) $SET_NO_BACK"
-                read -r -p "$COMMON_INPUT> " num
-                if [ "$num" = 1 ]; then
-                    line_break
-                    separator_line "="
-                    if [ "$crashcore" = "clash" ]; then
-                        rm -rf "$TMPDIR/CrashCore" "$CRASHDIR/CrashCore" "$CRASHDIR/CrashCore.tar.gz"
-                        crashcore=meta
-                        setconfig crashcore $crashcore
-                        top_box "$SET_SNIFFER_CORE_SWITCH" \
-                            ""
-                    fi
-                    sniffer=ON
-                else
-                    continue
-                fi
-            elif [ "$crashcore" = clashpre ] && [ "$dns_mod" = redir_host ]; then
-                msg_alert "\033[31m$SET_SNIFFER_LOCKED\033[0m"
-                continue
-            else
-                comp_box "$SET_SNIFFER_NOW\033[33m$SET_ENABLED\033[0m$SET_SNIFFER_DISABLE_Q"
-                btm_box "1) $SET_YES" \
-                    "0) $SET_NO_BACK"
-                read -r -p "$COMMON_INPUT> " num
-                if [ "$num" = 1 ]; then
-                    sniffer=OFF
-                    line_break
-                    separator_line "="
-                else
-                    continue
-                fi
-            fi
-            setconfig sniffer "$sniffer"
-            btm_box "\033[32m$COMMON_SUCCESS\033[0m"
-            sleep 1
-            ;;
-        6)
-            if pidof CrashCore >/dev/null; then
-                comp_box "\033[33m$SET_CORE_RUNNING\033[0m" \
-                    "$SET_CORE_STOP_CONFIRM"
-                btm_box "1) $SET_YES" \
-                    "0) $SET_NO_BACK"
-                read -r -p "$COMMON_INPUT> " res
-                if [ "$res" = 1 ]; then
-                    "$CRASHDIR/start.sh" stop && set_adv_config
-                else
-                    continue
-                fi
-            else
-                set_adv_config
-            fi
-            ;;
-        7)
-            set_ipv6
-            ;;
-        a)
-            BACK_TAR="$CRASHDIR/configs.tar.gz"
-            comp_box "1) $SET_BACKUP" \
-                "2) $SET_RESTORE" \
-                "3) $SET_RESET" \
-                "" \
-                "0) $COMMON_BACK"
-            read -r -p "$COMMON_INPUT> " num
-            case "$num" in
-            "" | 0)
-                continue
-                ;;
-            1)
-                line_break
-                separator_line "="
-                if tar -zcf "$BACK_TAR" -C "$CRASHDIR/configs/" .; then
-                    content_line "\033[32m$SET_BACKUP_OK $BACK_TAR\033[0m"
-                else
-                    content_line "\033[31m$SET_BACKUP_FAIL\033[0m"
-                fi
-                separator_line "="
-                sleep 1
-                continue
-                ;;
-            2)
-                line_break
-                separator_line "="
-                if [ -f "$BACK_TAR" ]; then
-                    tar -zcf "$TMPDIR/configs.tar.gz" -C "$CRASHDIR/configs/" .
-                    rm -rf "$CRASHDIR/configs/*"
-                    tar -zxf "$BACK_TAR" -C "$CRASHDIR"/configs
-                    mv -f "$TMPDIR/configs.tar.gz" "$BACK_TAR"
-                    content_line "\033[32m$SET_RESTORE_OK $BACK_TAR\033[0m"
-                else
-                    content_line "\033[31m$SET_BACKUP_MISS\033[0m"
-                fi
-                ;;
-            3)
-                line_break
-                separator_line "="
-                if tar -zcf "$BACK_TAR" -C "$CRASHDIR/configs/" .; then
-                    rm -rf "$CRASHDIR/configs"
-                    . "$CRASHDIR/init.sh" >/dev/null
-                    content_lin e"\033[32m$SET_RESET_OK\033[0m"
-                else
-                    content_lin e"\033[32m$SET_RESET_FAIL\033[0m"
-                fi
-                ;;
-            *)
-                errornum
-                continue
-                ;;
-            esac
-            content_line "\033[33m$SET_NEED_RESTART\033[0m"
-            separator_line "="
-            line_break
-            sleep 1
-            exit 0
-            ;;
-        b)
-            comp_box "1) $SET_LANG_ZH" \
-                "2) $SET_LANG_EN" \
-                "" \
-                "0) $COMMON_BACK"
-            read -r -p "$COMMON_INPUT> " num
-            case "$num" in
-            "" | 0)
-                continue
-                ;;
-            1)
-                echo chs >"$CRASHDIR"/configs/i18n.cfg
-                msg_alert "\033[32m$SET_SWITCH_RERUN\033[0m"
-                ;;
-            2)
-                echo en >"$CRASHDIR"/configs/i18n.cfg
-                msg_alert "\033[32mLanguage switched successfully! Please re-run the script!\033[0m"
-                ;;
-            esac
-            line_break
-            exit 0
-            ;;
-        c)
-            comp_box "1) New Design by Sofia-Riese" \
-                "2) TUI-lite" \
-                "" \
-                "0) $COMMON_BACK"
-            read -r -p "$COMMON_INPUT> " num
-            case "$num" in
-            "" | 0)
-                continue
-                ;;
-            1)
-                setconfig tui_type 'tui_layout'
-                . "$CRASHDIR"/menus/tui_layout.sh
-                ;;
-            2)
-                setconfig tui_type 'tui_lite'
-                . "$CRASHDIR"/menus/tui_lite.sh
-                ;;
-            esac
-            msg_alert "\033[32m$SET_SWITCH_OK\033[0m"
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+		comp_box "\033[30;47m$SET_MENU_TITLE\033[0m"
+		content_line "1) $SET_MENU_REDIR\t\033[36m$redir_mod$MENU_MOD\033[0m"
+		content_line "2) $SET_MENU_DNS\t\033[36m$dns_mod\033[0m"
+		content_line "3) $SET_MENU_FW_FILTER"
+		[ "$disoverride" != "1" ] && {
+			content_line "4) $SET_MENU_SKIP_CERT\t\033[36m$skip_cert\033[0m"
+			content_line "5) $SET_MENU_SNIFFER\t\033[36m$sniffer\033[0m"
+			content_line "6) $SET_MENU_ADV_PORT"
+		}
+		content_line "7) $SET_MENU_IPV6\t\033[36m$ipv6_redir\033[0m"
+		btm_box "" \
+			"a) \033[31m$SET_MENU_RESET\033[0m" \
+			"b) \033[36m$SET_MENU_LANG\033[0m" \
+			"c) \033[33m$SET_MENU_UI\033[0m" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ "$USER" != root ] && [ "$USER" != admin ]; then
+				comp_box "$SET_WARN_NONROOT"
+				btm_box "1) $SET_YES" \
+					"0) $SET_NO_BACK"
+				read -r -p "$COMMON_INPUT> " res
+				if [ "$res" = 1 ]; then
+					set_redir_mod
+				else
+					continue
+				fi
+			else
+				set_redir_mod
+			fi
+			;;
+		2)
+			. "$CRASHDIR"/menus/dns.sh && set_dns_mod
+			;;
+		3)
+			. "$CRASHDIR"/menus/fw_filter.sh && set_fw_filter
+			;;
+		4)
+			line_break
+			separator_line "="
+			if [ "$skip_cert" = "OFF" ]; then
+				content_line "$SET_SKIP_CERT_NOW\033[33m$SET_DISABLED\033[0m$SET_SKIP_CERT_ENABLE_Q"
+			else
+				content_line "$SET_SKIP_CERT_NOW\033[33m$SET_ENABLED\033[0m$SET_SKIP_CERT_DISABLE_Q"
+			fi
+			separator_line "="
+			btm_box "1) $SET_YES" \
+				"0) $SET_NO_BACK"
+			read -r -p "$COMMON_INPUT> " num
+			if [ "$num" = 1 ]; then
+				if [ "$skip_cert" = OFF ]; then
+					skip_cert=ON
+					msg_alert "\033[33m$SET_SKIP_CERT_ON\033[0m"
+				else
+					skip_cert=OFF
+					msg_alert "\033[33m$SET_SKIP_CERT_OFF\033[0m"
+				fi
+				setconfig skip_cert $skip_cert
+			else
+				continue
+			fi
+			;;
+		5)
+			if [ "$sniffer" = "OFF" ]; then
+				comp_box "$SET_SNIFFER_NOW\033[33m$SET_DISABLED\033[0m$SET_SNIFFER_ENABLE_Q"
+				btm_box "1) $SET_YES" \
+					"0) $SET_NO_BACK"
+				read -r -p "$COMMON_INPUT> " num
+				if [ "$num" = 1 ]; then
+					line_break
+					separator_line "="
+					if [ "$crashcore" = "clash" ]; then
+						rm -rf "$TMPDIR/CrashCore" "$CRASHDIR/CrashCore" "$CRASHDIR/CrashCore.tar.gz"
+						crashcore=meta
+						setconfig crashcore $crashcore
+						top_box "$SET_SNIFFER_CORE_SWITCH" \
+							""
+					fi
+					sniffer=ON
+				else
+					continue
+				fi
+			elif [ "$crashcore" = clashpre ] && [ "$dns_mod" = redir_host ]; then
+				msg_alert "\033[31m$SET_SNIFFER_LOCKED\033[0m"
+				continue
+			else
+				comp_box "$SET_SNIFFER_NOW\033[33m$SET_ENABLED\033[0m$SET_SNIFFER_DISABLE_Q"
+				btm_box "1) $SET_YES" \
+					"0) $SET_NO_BACK"
+				read -r -p "$COMMON_INPUT> " num
+				if [ "$num" = 1 ]; then
+					sniffer=OFF
+					line_break
+					separator_line "="
+				else
+					continue
+				fi
+			fi
+			setconfig sniffer "$sniffer"
+			btm_box "\033[32m$COMMON_SUCCESS\033[0m"
+			sleep 1
+			;;
+		6)
+			if pidof CrashCore >/dev/null; then
+				comp_box "\033[33m$SET_CORE_RUNNING\033[0m" \
+					"$SET_CORE_STOP_CONFIRM"
+				btm_box "1) $SET_YES" \
+					"0) $SET_NO_BACK"
+				read -r -p "$COMMON_INPUT> " res
+				if [ "$res" = 1 ]; then
+					"$CRASHDIR/start.sh" stop && set_adv_config
+				else
+					continue
+				fi
+			else
+				set_adv_config
+			fi
+			;;
+		7)
+			set_ipv6
+			;;
+		a)
+			BACK_TAR="$CRASHDIR/configs.tar.gz"
+			comp_box "1) $SET_BACKUP" \
+				"2) $SET_RESTORE" \
+				"3) $SET_RESET" \
+				"" \
+				"0) $COMMON_BACK"
+			read -r -p "$COMMON_INPUT> " num
+			case "$num" in
+			"" | 0)
+				continue
+				;;
+			1)
+				line_break
+				separator_line "="
+				if tar -zcf "$BACK_TAR" -C "$CRASHDIR/configs/" .; then
+					content_line "\033[32m$SET_BACKUP_OK $BACK_TAR\033[0m"
+				else
+					content_line "\033[31m$SET_BACKUP_FAIL\033[0m"
+				fi
+				separator_line "="
+				sleep 1
+				continue
+				;;
+			2)
+				line_break
+				separator_line "="
+				if [ -f "$BACK_TAR" ]; then
+					tar -zcf "$TMPDIR/configs.tar.gz" -C "$CRASHDIR/configs/" .
+					rm -rf "$CRASHDIR/configs/*"
+					tar -zxf "$BACK_TAR" -C "$CRASHDIR"/configs
+					mv -f "$TMPDIR/configs.tar.gz" "$BACK_TAR"
+					content_line "\033[32m$SET_RESTORE_OK $BACK_TAR\033[0m"
+				else
+					content_line "\033[31m$SET_BACKUP_MISS\033[0m"
+				fi
+				;;
+			3)
+				line_break
+				separator_line "="
+				if tar -zcf "$BACK_TAR" -C "$CRASHDIR/configs/" .; then
+					rm -rf "$CRASHDIR/configs"
+					. "$CRASHDIR/init.sh" >/dev/null
+					content_lin e"\033[32m$SET_RESET_OK\033[0m"
+				else
+					content_lin e"\033[32m$SET_RESET_FAIL\033[0m"
+				fi
+				;;
+			*)
+				errornum
+				continue
+				;;
+			esac
+			content_line "\033[33m$SET_NEED_RESTART\033[0m"
+			separator_line "="
+			line_break
+			sleep 1
+			exit 0
+			;;
+		b)
+			comp_box "1) $SET_LANG_ZH" \
+				"2) $SET_LANG_EN" \
+				"" \
+				"0) $COMMON_BACK"
+			read -r -p "$COMMON_INPUT> " num
+			case "$num" in
+			"" | 0)
+				continue
+				;;
+			1)
+				echo chs >"$CRASHDIR"/configs/i18n.cfg
+				msg_alert "\033[32m$SET_SWITCH_RERUN\033[0m"
+				;;
+			2)
+				echo en >"$CRASHDIR"/configs/i18n.cfg
+				msg_alert "\033[32mLanguage switched successfully! Please re-run the script!\033[0m"
+				;;
+			esac
+			line_break
+			exit 0
+			;;
+		c)
+			comp_box "1) New Design by Sofia-Riese" \
+				"2) TUI-lite" \
+				"" \
+				"0) $COMMON_BACK"
+			read -r -p "$COMMON_INPUT> " num
+			case "$num" in
+			"" | 0)
+				continue
+				;;
+			1)
+				setconfig tui_type 'tui_layout'
+				. "$CRASHDIR"/menus/tui_layout.sh
+				;;
+			2)
+				setconfig tui_type 'tui_lite'
+				. "$CRASHDIR"/menus/tui_lite.sh
+				;;
+			esac
+			msg_alert "\033[32m$SET_SWITCH_OK\033[0m"
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 set_redir_config() {
-    setconfig redir_mod "$redir_mod"
-    setconfig dns_mod "$dns_mod"
-    msg_alert "\033[36m$SET_REDIR_APPLIED $redir_mod $SET_MODE_SUFFIX\033[0m"
+	setconfig redir_mod "$redir_mod"
+	setconfig dns_mod "$dns_mod"
+	msg_alert "\033[36m$SET_REDIR_APPLIED $redir_mod $SET_MODE_SUFFIX\033[0m"
 }
 
 # 路由模式设置
 set_redir_mod() {
-    while true; do
-        [ -n "$(ls /dev/net/tun 2>/dev/null)" ] || ip tuntap >/dev/null 2>&1 || modprobe tun 2>/dev/null && sup_tun=1
-        [ -z "$firewall_area" ] && firewall_area=1
-        [ "$firewall_area" = 4 ] && redir_mod="$MENU_PURE_MOD"
-        [ -z "$redir_mod" ] && redir_mod='Redir'
-        firewall_area_dsc=$(echo "$SET_FW_AREA_DESC($bypass_host)" | cut -d'|' -f$firewall_area)
-        comp_box "\033[33m$SET_REDIR_RESTART_HINT\033[0m" \
-            "$SET_REDIR_CURRENT\033[47;30m$redir_mod$MENU_MOD\033[0m；  $SET_CORE_CURRENT\033[47;30m$crashcore\033[0m"
-        [ "$firewall_area" -le 3 ] && {
-            content_line "1) $SET_SET_TO\033[32m$SET_REDIR_REDIR\033[0m：\t$SET_REDIR_REDIRDES"
-            content_line "2) $SET_SET_TO\033[36m$SET_REDIR_MIX\033[0m：\t$SET_REDIR_MIXDES"
-            content_line "3) $SET_SET_TO\033[32m$SET_REDIR_TPROXY\033[0m：\t$SET_REDIR_TPROXYDES"
-            content_line "4) $SET_SET_TO\033[33m$SET_REDIR_TUN\033[0m：\t$SET_REDIR_TUNDES"
-            content_line ""
-        }
-        [ "$firewall_area" = 5 ] && {
-            content_line "5) \033[32m$SET_BYPASS_TCP\033[0m：    $SET_BYPASS_TCP_DESC"
-            content_line "6) \033[36m$SET_BYPASS_TU\033[0m：    $SET_BYPASS_TU_DESC"
-            content_line ""
-        }
-        btm_box "7) $SET_FW_AREA：\t\033[47;30m$firewall_area_dsc\033[0m" \
-            "8) $SET_VM_REDIR：\t\033[47;30m$vm_redir\033[0m" \
-            "9) $SET_FW_SWITCH：\t\033[47;30m$firewall_mod\033[0m" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            redir_mod=Redir
-            set_redir_config
-            ;;
-        2)
-            if [ -n "$sup_tun" ]; then
-                redir_mod=Mix
-                set_redir_config
-            else
-                msg_alert "\033[31m${SET_NO_MOD}TUN\033[0m" \
-                    "\033[31m$SET_NO_MOD2\033[0m"
-            fi
-            ;;
-        3)
-            if [ "$firewall_mod" = "iptables" ]; then
-                if [ -f /etc/init.d/qca-nss-ecm ] && [ "$systype" = "mi_snapshot" ]; then
-                    read -r -p "$XIAOMI_QOS(1/0)> " res
-                    [ "$res" = '1' ] && {
-                        /data/shellcrash_init.sh tproxyfix
-                        redir_mod=Tproxy
-                        set_redir_config
-                    }
-                elif grep -qE '^TPROXY$' /proc/net/ip_tables_targets || modprobe xt_TPROXY >/dev/null 2>&1; then
-                    redir_mod=Tproxy
-                    set_redir_config
-                else
-                    msg_alert "\033[31m${SET_NO_MOD}iptables-mod-tproxy\033[0m" \
-                        "\033[31m$SET_NO_MOD2\033[0m"
-                fi
-            elif [ "$firewall_mod" = "nftables" ]; then
-                if modprobe nft_tproxy >/dev/null 2>&1 || lsmod 2>/dev/null | grep -q nft_tproxy; then
-                    redir_mod=Tproxy
-                    set_redir_config
-                else
-                    msg_alert "\033[31m${SET_NO_MOD}nft_tproxy\033[0m" \
-                        "\033[31m$SET_NO_MOD2\033[0m"
-                fi
-            fi
-            ;;
-        4)
-            if [ -n "$sup_tun" ]; then
-                redir_mod=Tun
-                set_redir_config
-            else
-                msg_alert "\033[31m$SET_NO_TUN\033[0m"
-            fi
-            ;;
-        5)
-            redir_mod='$SET_BYPASS_TCP'
-            set_redir_config
-            ;;
-        6)
-            redir_mod='$SET_BYPASS_TU'
-            set_redir_config
-            ;;
-        7)
-            set_firewall_area
-            ;;
-        8)
-            set_firewall_vm
-            ;;
-        9)
-            if [ "$firewall_mod" = 'iptables' ]; then
-                if nft add table inet shellcrash 2>/dev/null; then
-                    firewall_mod=nftables
-                    redir_mod=Redir
-                    setconfig redir_mod $redir_mod
-                else
-                    msg_alert "\033[31m$FW_NO_NFTABLES\033[0m"
-                fi
-            elif [ "$firewall_mod" = 'nftables' ]; then
-                if ckcmd iptables; then
-                    firewall_mod=iptables
-                    redir_mod=Redir
-                    setconfig redir_mod $redir_mod
-                else
-                    msg_alert "\033[31m$FW_NO_IPTABLES\033[0m"
-                fi
-            else
-                iptables -j REDIRECT -h >/dev/null 2>&1 && firewall_mod=iptables
-                nft add table inet shellcrash 2>/dev/null && firewall_mod=nftables
-                if [ -n "$firewall_mod" ]; then
-                    redir_mod=Redir
-                    setconfig redir_mod $redir_mod
-                    setconfig firewall_mod "$firewall_mod"
-                else
-                    msg_alert "\033[31m$FW_NO_FIREWALL_BACKEND\033[0m"
-                fi
-            fi
-            setconfig firewall_mod "$firewall_mod"
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+	while true; do
+		[ -n "$(ls /dev/net/tun 2>/dev/null)" ] || ip tuntap >/dev/null 2>&1 || modprobe tun 2>/dev/null && sup_tun=1
+		[ -z "$firewall_area" ] && firewall_area=1
+		[ "$firewall_area" = 4 ] && redir_mod="$MENU_PURE_MOD"
+		[ -z "$redir_mod" ] && redir_mod='Redir'
+		firewall_area_dsc=$(echo "$SET_FW_AREA_DESC($bypass_host)" | cut -d'|' -f$firewall_area)
+		comp_box "\033[33m$SET_REDIR_RESTART_HINT\033[0m" \
+			"$SET_REDIR_CURRENT\033[47;30m$redir_mod$MENU_MOD\033[0m；  $SET_CORE_CURRENT\033[47;30m$crashcore\033[0m"
+		[ "$firewall_area" -le 3 ] && {
+			content_line "1) $SET_SET_TO\033[32m$SET_REDIR_REDIR\033[0m：\t$SET_REDIR_REDIRDES"
+			content_line "2) $SET_SET_TO\033[36m$SET_REDIR_MIX\033[0m：\t$SET_REDIR_MIXDES"
+			content_line "3) $SET_SET_TO\033[32m$SET_REDIR_TPROXY\033[0m：\t$SET_REDIR_TPROXYDES"
+			content_line "4) $SET_SET_TO\033[33m$SET_REDIR_TUN\033[0m：\t$SET_REDIR_TUNDES"
+			content_line ""
+		}
+		[ "$firewall_area" = 5 ] && {
+			content_line "5) \033[32m$SET_BYPASS_TCP\033[0m：    $SET_BYPASS_TCP_DESC"
+			content_line "6) \033[36m$SET_BYPASS_TU\033[0m：    $SET_BYPASS_TU_DESC"
+			content_line ""
+		}
+		btm_box "7) $SET_FW_AREA：\t\033[47;30m$firewall_area_dsc\033[0m" \
+			"8) $SET_VM_REDIR：\t\033[47;30m$vm_redir\033[0m" \
+			"9) $SET_FW_SWITCH：\t\033[47;30m$firewall_mod\033[0m" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			redir_mod=Redir
+			set_redir_config
+			;;
+		2)
+			if [ -n "$sup_tun" ]; then
+				redir_mod=Mix
+				set_redir_config
+			else
+				msg_alert "\033[31m${SET_NO_MOD}TUN\033[0m" \
+					"\033[31m$SET_NO_MOD2\033[0m"
+			fi
+			;;
+		3)
+			if [ "$firewall_mod" = "iptables" ]; then
+				if [ -f /etc/init.d/qca-nss-ecm ] && [ "$systype" = "mi_snapshot" ]; then
+					read -r -p "$XIAOMI_QOS(1/0)> " res
+					[ "$res" = '1' ] && {
+						/data/shellcrash_init.sh tproxyfix
+						redir_mod=Tproxy
+						set_redir_config
+					}
+				elif grep -qE '^TPROXY$' /proc/net/ip_tables_targets || modprobe xt_TPROXY >/dev/null 2>&1; then
+					redir_mod=Tproxy
+					set_redir_config
+				else
+					msg_alert "\033[31m${SET_NO_MOD}iptables-mod-tproxy\033[0m" \
+						"\033[31m$SET_NO_MOD2\033[0m"
+				fi
+			elif [ "$firewall_mod" = "nftables" ]; then
+				if modprobe nft_tproxy >/dev/null 2>&1 || lsmod 2>/dev/null | grep -q nft_tproxy; then
+					redir_mod=Tproxy
+					set_redir_config
+				else
+					msg_alert "\033[31m${SET_NO_MOD}nft_tproxy\033[0m" \
+						"\033[31m$SET_NO_MOD2\033[0m"
+				fi
+			fi
+			;;
+		4)
+			if [ -n "$sup_tun" ]; then
+				redir_mod=Tun
+				set_redir_config
+			else
+				msg_alert "\033[31m$SET_NO_TUN\033[0m"
+			fi
+			;;
+		5)
+			redir_mod='$SET_BYPASS_TCP'
+			set_redir_config
+			;;
+		6)
+			redir_mod='$SET_BYPASS_TU'
+			set_redir_config
+			;;
+		7)
+			set_firewall_area
+			;;
+		8)
+			set_firewall_vm
+			;;
+		9)
+			if [ "$firewall_mod" = 'iptables' ]; then
+				if nft add table inet shellcrash 2>/dev/null; then
+					firewall_mod=nftables
+					redir_mod=Redir
+					setconfig redir_mod $redir_mod
+				else
+					msg_alert "\033[31m$FW_NO_NFTABLES\033[0m"
+				fi
+			elif [ "$firewall_mod" = 'nftables' ]; then
+				if ckcmd iptables; then
+					firewall_mod=iptables
+					redir_mod=Redir
+					setconfig redir_mod $redir_mod
+				else
+					msg_alert "\033[31m$FW_NO_IPTABLES\033[0m"
+				fi
+			else
+				iptables -j REDIRECT -h >/dev/null 2>&1 && firewall_mod=iptables
+				nft add table inet shellcrash 2>/dev/null && firewall_mod=nftables
+				if [ -n "$firewall_mod" ]; then
+					redir_mod=Redir
+					setconfig redir_mod $redir_mod
+					setconfig firewall_mod "$firewall_mod"
+				else
+					msg_alert "\033[31m$FW_NO_FIREWALL_BACKEND\033[0m"
+				fi
+			fi
+			setconfig firewall_mod "$firewall_mod"
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 inputport() {
-    line_break
-    read -r -p "$INPUT_PORT（1～65535）> " portx
-    . "$CRASHDIR"/menus/check_port.sh # 加载测试函数
-    if check_port "$portx"; then
-        setconfig "$xport" "$portx"
-        msg_alert "\033[32m$COMMON_SUCCESS\033[0m"
-        return 0
-    else
-        msg_alert "\033[31m$COMMON_FAILED\033[0m"
-        return 1
-    fi
+	local protocol="${1:-all}"
+	line_break
+	read -r -p "$INPUT_PORT（1～65535）> " portx
+	. "$CRASHDIR"/menus/check_port.sh
+	if check_port "$portx" "$protocol"; then
+		setconfig "$xport" "$portx"
+		msg_alert "\033[32m$COMMON_SUCCESS\033[0m"
+		return 0
+	else
+		msg_alert "\033[31m$COMMON_FAILED\033[0m"
+		return 1
+	fi
 }
 
 # 端口设置
 set_adv_config() {
-    while true; do
-        . "$CFG_PATH" >/dev/null
-        [ -z "$secret" ] && secret="$COMMON_UNSET"
-        [ -z "$table" ] && table=100
-        [ -z "$authentication" ] && auth="$COMMON_UNSET" || auth="******"
-        comp_box "1) $ADV_HTTP_PORT：\t\033[36m$mix_port\033[0m" \
-            "2) $ADV_HTTP_AUTH：\t\033[36m$auth\033[0m" \
-            "3) $ADV_REDIR_PORT：\t\033[36m$redir_port,$((redir_port + 1))\033[0m" \
-            "4) $ADV_DNS_PORT：\t\t\033[36m$dns_port\033[0m" \
-            "5) $ADV_PANEL_PORT：\t\t\033[36m$db_port\033[0m" \
-            "6) $ADV_PANEL_PASS：\t\t\033[36m$secret\033[0m" \
-            "8) $ADV_HOST：\t\033[36m$host\033[0m" \
-            "9) $ADV_TABLE：\t\t\033[36m$table,$((table + 1))\033[0m" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            xport=mix_port
-            inputport
-            if [ $? -eq 1 ]; then
-                break
-            else
-                continue
-            fi
-            ;;
-        2)
-            comp_box "$ADV_AUTH_FORMAT_DESC" \
-                "$ADV_AUTH_WARN" \
-                "$ADV_AUTH_REMOVE_HINT"
-            read -r -p "$ADV_AUTH_INPUT> " input
-            if [ "$input" = "0" ]; then
-                authentication=""
-                setconfig authentication
-                msg_alert "\033[32m$ADV_AUTH_REMOVED\033[0m"
-            else
-                if [ "$local_proxy" = "ON" ] && [ "$local_type" = "$LOCAL_TYPE_ENV" ]; then
-                    msg_alert "\033[33m$ADV_AUTH_ENV_CONFLICT\033[0m"
-                else
-                    authentication=$(echo "$input" | grep :)
-                    if [ -n "$authentication" ]; then
-                        setconfig authentication "'$authentication'"
-                        msg_alert "\033[32m$COMMON_SUCCESS\033[0m"
-                    else
-                        msg_alert "\033[31m$ADV_AUTH_INVALID\033[0m"
-                    fi
-                fi
-            fi
-            ;;
-        3)
-            xport=redir_port
-            inputport
-            if [ $? -eq 1 ]; then
-                break
-            else
-                continue
-            fi
-            ;;
-        4)
-            xport=dns_port
-            inputport
-            if [ $? -eq 1 ]; then
-                break
-            else
-                continue
-            fi
-            ;;
-        5)
-            xport=db_port
-            inputport
-            if [ $? -eq 1 ]; then
-                break
-            else
-                continue
-            fi
-            ;;
-        6)
-            line_break
-            read -r -p "$ADV_PANEL_PASS_INPUT> " secret
-            if [ -n "$secret" ]; then
-                [ "$secret" = "0" ] && secret=""
-                if setconfig secret "$secret"; then
-                    common_success
-                else
-                    common_failed
-                fi
-            fi
-            ;;
-        8)
-            comp_box "\033[33m$ADV_HOST_WARN_LAN\033[0m" \
-                "\033[31m$ADV_HOST_WARN_CHANGE\033[0m"
-            read -r -p "$ADV_HOST_INPUT> " host
-            if [ "$host" = "0" ]; then
-                host=""
-                setconfig host "$host"
-                msg_alert "\033[32m$ADV_HOST_REMOVED\033[0m"
-                line_break
-                exit 0
-            elif echo "$host" | grep -Eq '\<([1-9]|[1-9][0-9]|1[0-9]{2}|2[01][0-9]|22[0-3])\>(\.\<([0-9]|[0-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\>){2}\.\<([1-9]|[0-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-4])\>'; then
-                if setconfig host "$host"; then
-                    common_success
-                else
-                    common_failed
-                fi
-            else
-                host=""
-                msg_alert "\033[31m$ADV_HOST_INVALID\033[0m"
-            fi
-            ;;
-        9)
-            comp_box "\033[33m$ADV_TABLE_WARN\033[0m"
-            read -r -p "$ADV_TABLE_INPUT> " table
-            if [ -n "$table" ]; then
-                [ "$table" = "0" ] && table="100"
-                if setconfig table "$table"; then
-                    common_success
-                else
-                    common_failed
-                fi
-            fi
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+	while true; do
+		. "$CFG_PATH" >/dev/null
+		[ -z "$secret" ] && secret="$COMMON_UNSET"
+		[ -z "$table" ] && table=100
+		[ -z "$authentication" ] && auth="$COMMON_UNSET" || auth="******"
+		comp_box "1) $ADV_HTTP_PORT：\t\033[36m$mix_port\033[0m" \
+			"2) $ADV_HTTP_AUTH：\t\033[36m$auth\033[0m" \
+			"3) $ADV_REDIR_PORT：\t\033[36m$redir_port,$((redir_port + 1))\033[0m" \
+			"4) $ADV_DNS_PORT：\t\t\033[36m$dns_port\033[0m" \
+			"5) $ADV_PANEL_PORT：\t\t\033[36m$db_port\033[0m" \
+			"6) $ADV_PANEL_PASS：\t\t\033[36m$secret\033[0m" \
+			"8) $ADV_HOST：\t\033[36m$host\033[0m" \
+			"9) $ADV_TABLE：\t\t\033[36m$table,$((table + 1))\033[0m" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			xport=mix_port
+			inputport tcp
+			if [ $? -eq 1 ]; then
+				break
+			else
+				continue
+			fi
+			;;
+		2)
+			comp_box "$ADV_AUTH_FORMAT_DESC" \
+				"$ADV_AUTH_WARN" \
+				"$ADV_AUTH_REMOVE_HINT"
+			read -r -p "$ADV_AUTH_INPUT> " input
+			if [ "$input" = "0" ]; then
+				authentication=""
+				setconfig authentication
+				msg_alert "\033[32m$ADV_AUTH_REMOVED\033[0m"
+			else
+				if [ "$local_proxy" = "ON" ] && [ "$local_type" = "$LOCAL_TYPE_ENV" ]; then
+					msg_alert "\033[33m$ADV_AUTH_ENV_CONFLICT\033[0m"
+				else
+					authentication=$(echo "$input" | grep :)
+					if [ -n "$authentication" ]; then
+						setconfig authentication "'$authentication'"
+						msg_alert "\033[32m$COMMON_SUCCESS\033[0m"
+					else
+						msg_alert "\033[31m$ADV_AUTH_INVALID\033[0m"
+					fi
+				fi
+			fi
+			;;
+		3)
+			xport=redir_port
+			inputport tcp
+			if [ $? -eq 1 ]; then
+				break
+			else
+				continue
+			fi
+			;;
+		4)
+			xport=dns_port
+			inputport all
+			if [ $? -eq 1 ]; then
+				break
+			else
+				continue
+			fi
+			;;
+		5)
+			xport=db_port
+			inputport tcp
+			if [ $? -eq 1 ]; then
+				break
+			else
+				continue
+			fi
+			;;
+		6)
+			line_break
+			read -r -p "$ADV_PANEL_PASS_INPUT> " secret
+			if [ -n "$secret" ]; then
+				[ "$secret" = "0" ] && secret=""
+				if setconfig secret "$secret"; then
+					common_success
+				else
+					common_failed
+				fi
+			fi
+			;;
+		8)
+			comp_box "\033[33m$ADV_HOST_WARN_LAN\033[0m" \
+				"\033[31m$ADV_HOST_WARN_CHANGE\033[0m"
+			read -r -p "$ADV_HOST_INPUT> " host
+			if [ "$host" = "0" ]; then
+				host=""
+				setconfig host "$host"
+				msg_alert "\033[32m$ADV_HOST_REMOVED\033[0m"
+				line_break
+				exit 0
+			elif echo "$host" | grep -Eq '\<([1-9]|[1-9][0-9]|1[0-9]{2}|2[01][0-9]|22[0-3])\>(\.\<([0-9]|[0-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\>){2}\.\<([1-9]|[0-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-4])\>'; then
+				if setconfig host "$host"; then
+					common_success
+				else
+					common_failed
+				fi
+			else
+				host=""
+				msg_alert "\033[31m$ADV_HOST_INVALID\033[0m"
+			fi
+			;;
+		9)
+			comp_box "\033[33m$ADV_TABLE_WARN\033[0m"
+			read -r -p "$ADV_TABLE_INPUT> " table
+			if [ -n "$table" ]; then
+				[ "$table" = "0" ] && table="100"
+				if setconfig table "$table"; then
+					common_success
+				else
+					common_failed
+				fi
+			fi
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 set_firewall_area() {
-    while true; do
-        [ -z "$vm_redir" ] && vm_redir='OFF'
-        comp_box "\033[33m$FW_AREA_NOTE_1\033[0m" \
-            "\033[33m$FW_AREA_NOTE_2\033[0m" \
-            "" \
-            "$SET_FW_AREA_CURRENT$firewall_area_dsc"
-        btm_box "1) \033[32m$FW_AREA_LAN\033[0m" \
-            "2) \033[36m$FW_AREA_LOCAL\033[0m" \
-            "3) \033[32m$FW_AREA_BOTH\033[0m" \
-            "4) $FW_AREA_NONE" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        [1-4])
-            if [ "$firewall_area" -ge 4 ]; then
-                redir_mod=''
-            else
-                redir_mod=Redir
-            fi
-            firewall_area="$num"
-            setconfig firewall_area "$firewall_area"
-            setconfig redir_mod "$redir_mod"
+	while true; do
+		[ -z "$vm_redir" ] && vm_redir='OFF'
+		comp_box "\033[33m$FW_AREA_NOTE_1\033[0m" \
+			"\033[33m$FW_AREA_NOTE_2\033[0m" \
+			"" \
+			"$SET_FW_AREA_CURRENT$firewall_area_dsc"
+		btm_box "1) \033[32m$FW_AREA_LAN\033[0m" \
+			"2) \033[36m$FW_AREA_LOCAL\033[0m" \
+			"3) \033[32m$FW_AREA_BOTH\033[0m" \
+			"4) $FW_AREA_NONE" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		[1-4])
+			if [ "$firewall_area" -ge 4 ]; then
+				redir_mod=''
+			else
+				redir_mod=Redir
+			fi
+			firewall_area="$num"
+			setconfig firewall_area "$firewall_area"
+			setconfig redir_mod "$redir_mod"
 
-            case "$firewall_area" in
-            1) firewall_area_dsc="$FW_AREA_LAN" ;;
-            2) firewall_area_dsc="$FW_AREA_LOCAL" ;;
-            3) firewall_area_dsc="$FW_AREA_BOTH" ;;
-            4) firewall_area_dsc="$FW_AREA_NONE" ;;
-            esac
+			case "$firewall_area" in
+			1) firewall_area_dsc="$FW_AREA_LAN" ;;
+			2) firewall_area_dsc="$FW_AREA_LOCAL" ;;
+			3) firewall_area_dsc="$FW_AREA_BOTH" ;;
+			4) firewall_area_dsc="$FW_AREA_NONE" ;;
+			esac
 
-            common_success
-            ;;
-        5)
-            comp_box "\033[31m$SET_WARN\033[0m" \
-                "$SET_BYPASS_WARN_1" \
-                "$SET_BYPASS_WARN_2" \
-                "$SET_BYPASS_WARN_3" \
-                "\033[33m$SET_DESC\033[0m" \
-                "$SET_BYPASS_DESC_1" \
-                "$SET_BYPASS_DESC_2"
-            read -r -p "$SET_INPUT_BYPASS_IPV4> " bypass_host
-            [ -n "$bypass_host" ] && {
-                firewall_area=$num
-                setconfig firewall_area "$firewall_area"
-                setconfig bypass_host "$bypass_host"
-                redir_mod=$SET_BYPASS_TCP
-                setconfig redir_mod $redir_mod
-            }
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+			common_success
+			;;
+		5)
+			comp_box "\033[31m$SET_WARN\033[0m" \
+				"$SET_BYPASS_WARN_1" \
+				"$SET_BYPASS_WARN_2" \
+				"$SET_BYPASS_WARN_3" \
+				"\033[33m$SET_DESC\033[0m" \
+				"$SET_BYPASS_DESC_1" \
+				"$SET_BYPASS_DESC_2"
+			read -r -p "$SET_INPUT_BYPASS_IPV4> " bypass_host
+			[ -n "$bypass_host" ] && {
+				firewall_area=$num
+				setconfig firewall_area "$firewall_area"
+				setconfig bypass_host "$bypass_host"
+				redir_mod=$SET_BYPASS_TCP
+				setconfig redir_mod $redir_mod
+			}
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 set_firewall_vm() {
-    [ -z "$vm_ipv4" ] && vm_ipv4=$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'brd' | grep -E 'docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet' | sed 's/.*inet.//g' | sed 's/ br.*$//g' | sed 's/metric.*$//g' | tr '\n' ' ')
-    comp_box "$VM_DETECT_DESC\033[32m$vm_ipv4\033[0m"
-    btm_box "1) \033[32m$VM_ENABLE_AUTO\033[0m" \
-        "2) \033[36m$VM_ENABLE_MANUAL\033[0m" \
-        "3) \033[31m$VM_DISABLE\033[0m" \
-        "" \
-        "0) $COMMON_BACK"
-    read -r -p "$COMMON_INPUT> " num
-    case "$num" in
-    1)
-        if [ -n "$vm_ipv4" ]; then
-            vm_redir=ON
-            common_success
-        else
-            msg_alert "\033[33m$VM_NO_NET_DETECTED\033[0m"
-        fi
+	[ -z "$vm_ipv4" ] && vm_ipv4=$(ip a 2>&1 | grep -w 'inet' | grep 'global' | grep 'brd' | grep -E 'docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet' | sed 's/.*inet.//g' | sed 's/ br.*$//g' | sed 's/metric.*$//g' | tr '\n' ' ')
+	comp_box "$VM_DETECT_DESC\033[32m$vm_ipv4\033[0m"
+	btm_box "1) \033[32m$VM_ENABLE_AUTO\033[0m" \
+		"2) \033[36m$VM_ENABLE_MANUAL\033[0m" \
+		"3) \033[31m$VM_DISABLE\033[0m" \
+		"" \
+		"0) $COMMON_BACK"
+	read -r -p "$COMMON_INPUT> " num
+	case "$num" in
+	1)
+		if [ -n "$vm_ipv4" ]; then
+			vm_redir=ON
+			common_success
+		else
+			msg_alert "\033[33m$VM_NO_NET_DETECTED\033[0m"
+		fi
 
-        ;;
-    2)
-        comp_box "$VM_INPUT_DESC_1" \
-            "$VM_INPUT_DESC_2 \033[32m10.88.0.0/16 172.17.0.0/16\033[0m" \
-            "" \
-            "$SET_TIPS_ENTER_BACK"
-        read -r -p "$VM_INPUT_NET> " text
-        [ -n "$text" ] && vm_ipv4="$text" && vm_redir=ON
-        ;;
-    3)
-        vm_redir=OFF
-        vm_ipv4=''
-        common_success
-        ;;
-    *) ;;
-    esac
-    case "$num" in
-    1-3)
-        setconfig vm_redir "$vm_redir"
-        setconfig vm_ipv4 "'$vm_ipv4'"
-        ;;
-    esac
+		;;
+	2)
+		comp_box "$VM_INPUT_DESC_1" \
+			"$VM_INPUT_DESC_2 \033[32m10.88.0.0/16 172.17.0.0/16\033[0m" \
+			"" \
+			"$SET_TIPS_ENTER_BACK"
+		read -r -p "$VM_INPUT_NET> " text
+		[ -n "$text" ] && vm_ipv4="$text" && vm_redir=ON
+		;;
+	3)
+		vm_redir=OFF
+		vm_ipv4=''
+		common_success
+		;;
+	*) ;;
+	esac
+	case "$num" in
+	1-3)
+		setconfig vm_redir "$vm_redir"
+		setconfig vm_ipv4 "'$vm_ipv4'"
+		;;
+	esac
 }
 
 # ipv6设置
 set_ipv6() {
-    while true; do
-        [ -z "$ipv6_redir" ] && ipv6_redir=OFF
-        [ -z "$ipv6_dns" ] && ipv6_dns=ON
+	while true; do
+		[ -z "$ipv6_redir" ] && ipv6_redir=OFF
+		[ -z "$ipv6_dns" ] && ipv6_dns=ON
 
-        top_box "1) $IPV6_REDIR：\t\033[36m$ipv6_redir\033[0m"
-        [ "$disoverride" != "1" ] && content_line "2) $IPV6_DNS：\t\033[36m$ipv6_dns\033[0m"
-        btm_box "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ "$ipv6_redir" = "OFF" ]; then
-                ipv6_support=ON
-                ipv6_redir=ON
-            else
-                ipv6_redir=OFF
-            fi
-            setconfig ipv6_redir $ipv6_redir
-            setconfig ipv6_support "$ipv6_support"
-            common_success
-            ;;
-        2)
-            [ "$ipv6_dns" = OFF ] && ipv6_dns=ON || ipv6_dns=OFF
-            if setconfig ipv6_dns "$ipv6_dns"; then
-                common_success
-            else
-                common_failed
-            fi
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+		top_box "1) $IPV6_REDIR：\t\033[36m$ipv6_redir\033[0m"
+		[ "$disoverride" != "1" ] && content_line "2) $IPV6_DNS：\t\033[36m$ipv6_dns\033[0m"
+		btm_box "" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ "$ipv6_redir" = "OFF" ]; then
+				ipv6_support=ON
+				ipv6_redir=ON
+			else
+				ipv6_redir=OFF
+			fi
+			setconfig ipv6_redir $ipv6_redir
+			setconfig ipv6_support "$ipv6_support"
+			common_success
+			;;
+		2)
+			[ "$ipv6_dns" = OFF ] && ipv6_dns=ON || ipv6_dns=OFF
+			if setconfig ipv6_dns "$ipv6_dns"; then
+				common_success
+			else
+				common_failed
+			fi
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }

--- a/scripts/menus/2_settings.sh
+++ b/scripts/menus/2_settings.sh
@@ -439,7 +439,7 @@ set_adv_config() {
 			;;
 		1)
 			xport=mix_port
-			inputport tcp
+			inputport
 			if [ $? -eq 1 ]; then
 				break
 			else
@@ -471,7 +471,7 @@ set_adv_config() {
 			;;
 		3)
 			xport=redir_port
-			inputport tcp
+			inputport
 			if [ $? -eq 1 ]; then
 				break
 			else
@@ -480,7 +480,7 @@ set_adv_config() {
 			;;
 		4)
 			xport=dns_port
-			inputport all
+			inputport
 			if [ $? -eq 1 ]; then
 				break
 			else

--- a/scripts/menus/7_gateway.sh
+++ b/scripts/menus/7_gateway.sh
@@ -11,176 +11,176 @@ load_lang 7_gateway
 
 # 访问与控制主菜单
 gateway() {
-    while true; do
-        comp_box "\033[30;47m$GW_TITLE\033[0m"
-        content_line "1) $GW_MENU_FW_WAN			\033[32m$fw_wan\033[0m"
-        content_line "2) $GW_MENU_TG_BOT		\033[32m$bot_tg_service\033[0m"
-        content_line "3) $GW_MENU_DDNS"
-        [ "$disoverride" != "1" ] && {
-            content_line "4) $GW_MENU_VMESS		\033[32m$vms_service\033[0m"
-            content_line "5) $GW_MENU_SHADOWSOCKS	\033[32m$sss_service\033[0m"
-            content_line "6) $GW_MENU_TS	\033[32m$ts_service\033[0m"
-            content_line "7) $GW_MENU_WG	\033[32m$wg_service\033[0m"
-        }
-        btm_box "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ -n "$(pidof CrashCore)" ] && [ "$firewall_mod" = 'iptables' ]; then
-                comp_box "\033[33m$GW_FW_STOP_WARN\033[0m" \
-                    "$GW_CONFIRM_CONTINUE"
-                btm_box "1) $GW_YES" \
-                    "0) $GW_NO_BACK"
-                read -r -p "$COMMON_INPUT> " res
-                if [ "$res" = 1 ]; then
-                    "$CRASHDIR"/start.sh stop && set_fw_wan
-                else
-                    continue
-                fi
-            else
-                set_fw_wan
-            fi
-            ;;
-        2)
-            set_bot_tg
-            ;;
-        3)
-            . "$CRASHDIR"/menus/ddns.sh && ddns_menu
-            ;;
-        4)
-            set_vmess
-            ;;
-        5)
-            set_shadowsocks
-            ;;
-        6)
-            if echo "$crashcore" | grep -q 'sing'; then
-                set_tailscale
-            else
-                msg_alert "\033[33m$crashcore$GW_CORE_UNSUPPORTED\033[0m"
-            fi
-            ;;
-        7)
-            if echo "$crashcore" | grep -q 'sing'; then
-                set_wireguard
-            else
-                msg_alert "\033[33m$crashcore$GW_CORE_UNSUPPORTED\033[0m"
-            fi
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+	while true; do
+		comp_box "\033[30;47m$GW_TITLE\033[0m"
+		content_line "1) $GW_MENU_FW_WAN			\033[32m$fw_wan\033[0m"
+		content_line "2) $GW_MENU_TG_BOT		\033[32m$bot_tg_service\033[0m"
+		content_line "3) $GW_MENU_DDNS"
+		[ "$disoverride" != "1" ] && {
+			content_line "4) $GW_MENU_VMESS		\033[32m$vms_service\033[0m"
+			content_line "5) $GW_MENU_SHADOWSOCKS	\033[32m$sss_service\033[0m"
+			content_line "6) $GW_MENU_TS	\033[32m$ts_service\033[0m"
+			content_line "7) $GW_MENU_WG	\033[32m$wg_service\033[0m"
+		}
+		btm_box "" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ -n "$(pidof CrashCore)" ] && [ "$firewall_mod" = 'iptables' ]; then
+				comp_box "\033[33m$GW_FW_STOP_WARN\033[0m" \
+					"$GW_CONFIRM_CONTINUE"
+				btm_box "1) $GW_YES" \
+					"0) $GW_NO_BACK"
+				read -r -p "$COMMON_INPUT> " res
+				if [ "$res" = 1 ]; then
+					"$CRASHDIR"/start.sh stop && set_fw_wan
+				else
+					continue
+				fi
+			else
+				set_fw_wan
+			fi
+			;;
+		2)
+			set_bot_tg
+			;;
+		3)
+			. "$CRASHDIR"/menus/ddns.sh && ddns_menu
+			;;
+		4)
+			set_vmess
+			;;
+		5)
+			set_shadowsocks
+			;;
+		6)
+			if echo "$crashcore" | grep -q 'sing'; then
+				set_tailscale
+			else
+				msg_alert "\033[33m$crashcore$GW_CORE_UNSUPPORTED\033[0m"
+			fi
+			;;
+		7)
+			if echo "$crashcore" | grep -q 'sing'; then
+				set_wireguard
+			else
+				msg_alert "\033[33m$crashcore$GW_CORE_UNSUPPORTED\033[0m"
+			fi
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 # 公网防火墙
 set_fw_wan() {
-    while true; do
-        [ -z "$fw_wan" ] && fw_wan=ON
-        line_break
-        separator_line "="
-        content_line "\033[31m$GW_WARN\033[0m$GW_FW_VPS_HINT"
-        [ -n "$fw_wan_ports" ] &&
-            content_line "$GW_FW_MANUAL_PORTS\033[36m$fw_wan_ports\033[0m"
-        [ -n "$vms_port$sss_port" ] &&
-            content_line "$GW_FW_AUTO_PORTS\033[36m$vms_port $sss_port\033[0m"
-        content_line "$GW_FW_DEFAULT_BLOCK\033[33m$mix_port,$db_port\033[0m"
-        separator_line "="
-        btm_box "1) $GW_FW_TOGGLE\033[36m$fw_wan\033[0m" \
-            "2) $GW_FW_ADD_PORT" \
-            "3) $GW_FW_REMOVE_PORT" \
-            "4) $GW_FW_CLEAR_PORTS" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case $num in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ "$fw_wan" = ON ]; then
-                comp_box "$GW_FW_DISABLE_CONFIRM" \
-                    "$GW_FW_DISABLE_RISK"
-                btm_box "1) $GW_YES" \
-                    "0) $GW_NO_BACK"
-                read -r -p "$COMMON_INPUT> " res
-                if [ "$res" = 1 ]; then
-                    fw_wan=OFF
-                else
-                    fw_wan=ON
-                fi
-            else
-                fw_wan=ON
-            fi
-            setconfig fw_wan "$fw_wan"
-            ;;
-        2)
-            port_count=$(echo "$fw_wan_ports" | awk -F',' '{print NF}')
-            if [ "$port_count" -ge 10 ]; then
-                msg_alert "\033[31m$GW_FW_PORT_LIMIT\033[0m"
-            else
-                line_break
-                read -r -p "$GW_INPUT_ALLOW_PORT> " port
-                if echo ",$fw_wan_ports," | grep -q ",$port,"; then
-                    msg_alert "\033[31m$GW_ERR_DUP_PORT\033[0m"
-                elif [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
-                    msg_alert "\033[31m$GW_ERR_PORT_RANGE\033[0m"
-                else
-                    fw_wan_ports=$(echo "$fw_wan_ports,$port" | sed "s/^,//")
-                    if setconfig fw_wan_ports "$fw_wan_ports"; then
-                        common_success
-                    else
-                        common_faileds
-                    fi
-                fi
-            fi
-            ;;
-        3)
-            while true; do
-                comp_box "\033[36m$GW_INPUT_REMOVE_PORT\033[0m" \
-                    "$GW_INPUT_0_BACK"
-                read -r -p "$GW_INPUT_PLAIN> " port
-                if [ "$port" = 0 ]; then
-                    break
-                elif echo ",$fw_wan_ports," | grep -q ",$port,"; then
-                    if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
-                        msg_alert "\033[31m$GW_ERR_INPUT\033[0m" \
-                            "\033[31m$GW_ERR_PORT_RANGE\033[0m"
-                    else
-                        fw_wan_ports=$(echo ",$fw_wan_ports," | sed "s/,$port//; s/^,//; s/,$//")
-                        setconfig fw_wan_ports "$fw_wan_ports"
-                        break
-                    fi
-                else
-                    msg_alert "\033[31m$GW_ERR_INPUT\033[0m" \
-                        "\033[31m$GW_ERR_PORT_NOT_FOUND\033[0m"
-                fi
-            done
-            ;;
-        4)
-            fw_wan_ports=''
-            setconfig fw_wan_ports
-            msg_alert "\033[32m$GW_OK\033[0m"
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+	while true; do
+		[ -z "$fw_wan" ] && fw_wan=ON
+		line_break
+		separator_line "="
+		content_line "\033[31m$GW_WARN\033[0m$GW_FW_VPS_HINT"
+		[ -n "$fw_wan_ports" ] &&
+			content_line "$GW_FW_MANUAL_PORTS\033[36m$fw_wan_ports\033[0m"
+		[ -n "$vms_port$sss_port" ] &&
+			content_line "$GW_FW_AUTO_PORTS\033[36m$vms_port $sss_port\033[0m"
+		content_line "$GW_FW_DEFAULT_BLOCK\033[33m$mix_port,$db_port\033[0m"
+		separator_line "="
+		btm_box "1) $GW_FW_TOGGLE\033[36m$fw_wan\033[0m" \
+			"2) $GW_FW_ADD_PORT" \
+			"3) $GW_FW_REMOVE_PORT" \
+			"4) $GW_FW_CLEAR_PORTS" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case $num in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ "$fw_wan" = ON ]; then
+				comp_box "$GW_FW_DISABLE_CONFIRM" \
+					"$GW_FW_DISABLE_RISK"
+				btm_box "1) $GW_YES" \
+					"0) $GW_NO_BACK"
+				read -r -p "$COMMON_INPUT> " res
+				if [ "$res" = 1 ]; then
+					fw_wan=OFF
+				else
+					fw_wan=ON
+				fi
+			else
+				fw_wan=ON
+			fi
+			setconfig fw_wan "$fw_wan"
+			;;
+		2)
+			port_count=$(echo "$fw_wan_ports" | awk -F',' '{print NF}')
+			if [ "$port_count" -ge 10 ]; then
+				msg_alert "\033[31m$GW_FW_PORT_LIMIT\033[0m"
+			else
+				line_break
+				read -r -p "$GW_INPUT_ALLOW_PORT> " port
+				if echo ",$fw_wan_ports," | grep -q ",$port,"; then
+					msg_alert "\033[31m$GW_ERR_DUP_PORT\033[0m"
+				elif [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+					msg_alert "\033[31m$GW_ERR_PORT_RANGE\033[0m"
+				else
+					fw_wan_ports=$(echo "$fw_wan_ports,$port" | sed "s/^,//")
+					if setconfig fw_wan_ports "$fw_wan_ports"; then
+						common_success
+					else
+						common_faileds
+					fi
+				fi
+			fi
+			;;
+		3)
+			while true; do
+				comp_box "\033[36m$GW_INPUT_REMOVE_PORT\033[0m" \
+					"$GW_INPUT_0_BACK"
+				read -r -p "$GW_INPUT_PLAIN> " port
+				if [ "$port" = 0 ]; then
+					break
+				elif echo ",$fw_wan_ports," | grep -q ",$port,"; then
+					if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+						msg_alert "\033[31m$GW_ERR_INPUT\033[0m" \
+							"\033[31m$GW_ERR_PORT_RANGE\033[0m"
+					else
+						fw_wan_ports=$(echo ",$fw_wan_ports," | sed "s/,$port//; s/^,//; s/,$//")
+						setconfig fw_wan_ports "$fw_wan_ports"
+						break
+					fi
+				else
+					msg_alert "\033[31m$GW_ERR_INPUT\033[0m" \
+						"\033[31m$GW_ERR_PORT_NOT_FOUND\033[0m"
+				fi
+			done
+			;;
+		4)
+			fw_wan_ports=''
+			setconfig fw_wan_ports
+			msg_alert "\033[32m$GW_OK\033[0m"
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 # tg_BOT相关
 set_bot_tg_config() {
-    setconfig TG_TOKEN "$TOKEN" "$GT_CFG_PATH"
-    setconfig TG_CHATID "$chat_ID" "$GT_CFG_PATH"
-    # 设置机器人快捷命令
-    JSON=$(
-        cat <<EOF
+	setconfig TG_TOKEN "$TOKEN" "$GT_CFG_PATH"
+	setconfig TG_CHATID "$chat_ID" "$GT_CFG_PATH"
+	# 设置机器人快捷命令
+	JSON=$(
+		cat <<EOF
 {
   "commands": [
     {"command": "$my_alias", "description": "$GW_TG_CMD_MENU"},
@@ -188,189 +188,194 @@ set_bot_tg_config() {
   ]
 }
 EOF
-    )
-    TEXT="$GW_TG_DONE_PREFIX /$my_alias $GW_TG_DONE_SUFFIX"
-    . "$CRASHDIR"/libs/web_json.sh
-    bot_api="https://api.telegram.org/bot$TOKEN"
-    web_json_post "$bot_api/setMyCommands" "$JSON"
-    web_json_post "$bot_api/sendMessage" '{"chat_id":"'"$chat_ID"'","text":"'"$TEXT"'","parse_mode":"Markdown"}'
+	)
+	TEXT="$GW_TG_DONE_PREFIX /$my_alias $GW_TG_DONE_SUFFIX"
+	. "$CRASHDIR"/libs/web_json.sh
+	bot_api="https://api.telegram.org/bot$TOKEN"
+	web_json_post "$bot_api/setMyCommands" "$JSON"
+	web_json_post "$bot_api/sendMessage" '{"chat_id":"'"$chat_ID"'","text":"'"$TEXT"'","parse_mode":"Markdown"}'
 
-    comp_box "\033[32m$TEXT\033[0m"
+	comp_box "\033[32m$TEXT\033[0m"
 }
 
 set_bot_tg_init() {
-    . "$CRASHDIR"/menus/bot_tg_bind.sh && private_bot && set_bot
-    if [ "$?" = 0 ]; then
-        set_bot_tg_config
-        return 0
-    else
-        return 1
-    fi
+	. "$CRASHDIR"/menus/bot_tg_bind.sh && private_bot && set_bot
+	if [ "$?" = 0 ]; then
+		set_bot_tg_config
+		return 0
+	else
+		return 1
+	fi
 }
 
 set_bot_tg_service() {
-    if [ "$bot_tg_service" = ON ]; then
-        bot_tg_service=OFF
-        . "$CRASHDIR"/menus/bot_tg_service.sh && bot_tg_stop
-    else
-        bot_tg_service=ON
-        [ -n "$(pidof CrashCore)" ] && . "$CRASHDIR"/menus/bot_tg_service.sh && 
-            bot_tg_start && bot_tg_cron
-    fi
-    setconfig bot_tg_service "$bot_tg_service"
+	if [ "$bot_tg_service" = ON ]; then
+		bot_tg_service=OFF
+		. "$CRASHDIR"/menus/bot_tg_service.sh && bot_tg_stop
+	else
+		bot_tg_service=ON
+		[ -n "$(pidof CrashCore)" ] && . "$CRASHDIR"/menus/bot_tg_service.sh &&
+			bot_tg_start && bot_tg_cron
+	fi
+	setconfig bot_tg_service "$bot_tg_service"
 }
 
 set_bot_tg() {
-    while true; do
-        [ -n "$ts_auth_key" ] && ts_auth_key_info="$GW_SET"
-        [ -n "$TG_CHATID" ] && TG_CHATID_info="$GW_BOUND"
-        comp_box "\033[31m$GW_WARN\033[0m$GW_TG_WARN"
-        btm_box "1) $GW_TG_TOGGLE	\033[32m$bot_tg_service\033[0m" \
-            "2) $GW_TG_BIND	\033[32m$TG_CHATID_info\033[0m" \
+	while true; do
+		[ -n "$ts_auth_key" ] && ts_auth_key_info="$GW_SET"
+		[ -n "$TG_CHATID" ] && TG_CHATID_info="$GW_BOUND"
+		comp_box "\033[31m$GW_WARN\033[0m$GW_TG_WARN"
+		btm_box "1) $GW_TG_TOGGLE	\033[32m$bot_tg_service\033[0m" \
+			"2) $GW_TG_BIND	\033[32m$TG_CHATID_info\033[0m" \
 			"3) $GW_TG_MENUPUSH	\033[32m$TG_menupush\033[0m" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            . "$GT_CFG_PATH"
-            if [ -n "$TG_CHATID" ]; then
-                set_bot_tg_service
-            else
-                msg_alert "\033[31m$GW_TG_BIND_FIRST\033[0m"
-            fi
-            ;;
-        2)
-            if [ -n "$chat_ID" ] && [ -n "$push_TG" ] && [ "$push_TG" != 'publictoken' ]; then
-                comp_box "$GW_TG_BOUND_DETECTED" \
-                    "$GW_TG_USE_DIRECT"
-                btm_box "1) $GW_YES" \
-                    "0) $GW_NO"
-                read -r -p "$COMMON_INPUT> " res
-                if [ "$res" = 1 ]; then
-                    TOKEN="$push_TG"
-                    set_bot_tg_config
-                    continue
-                fi
-            fi
-            set_bot_tg_init
-            ;;
-        3)
-            if [ "$TG_menupush" = ON ];then
-                TG_menupush=OFF
-            else
-                TG_menupush=ON
-            fi
-            setconfig TG_menupush "$TG_menupush" "$GT_CFG_PATH"
-            set_bot_tg
-	;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			. "$GT_CFG_PATH"
+			if [ -n "$TG_CHATID" ]; then
+				set_bot_tg_service
+			else
+				msg_alert "\033[31m$GW_TG_BIND_FIRST\033[0m"
+			fi
+			;;
+		2)
+			if [ -n "$chat_ID" ] && [ -n "$push_TG" ] && [ "$push_TG" != 'publictoken' ]; then
+				comp_box "$GW_TG_BOUND_DETECTED" \
+					"$GW_TG_USE_DIRECT"
+				btm_box "1) $GW_YES" \
+					"0) $GW_NO"
+				read -r -p "$COMMON_INPUT> " res
+				if [ "$res" = 1 ]; then
+					TOKEN="$push_TG"
+					set_bot_tg_config
+					continue
+				fi
+			fi
+			set_bot_tg_init
+			;;
+		3)
+			if [ "$TG_menupush" = ON ]; then
+				TG_menupush=OFF
+			else
+				TG_menupush=ON
+			fi
+			setconfig TG_menupush "$TG_menupush" "$GT_CFG_PATH"
+			set_bot_tg
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 # 自定义入站
 set_vmess() {
-    while true; do
-        comp_box "\033[31m$GW_WARN\033[0m" \
-            "$GW_INBOUND_WARN_PORT" \
-            "$GW_INBOUND_WARN_BASIC" \
-            "\033[31m$GW_INBOUND_WARN_ILLEGAL\033[0m"
-        content_line "1) \033[32m$GW_VMS_TOGGLE\033[0m  \033[32m$vms_service\033[0m"
-        content_line "2) $GW_SET_LISTEN_PORT  \033[36m$vms_port\033[0m"
-        content_line "3) $GW_SET_WSPATH  \033[33m$vms_ws_path\033[0m"
-        content_line "4) $GW_SET_UUID  \033[36m$vms_uuid\033[0m"
-        content_line "5) $GW_GEN_RANDOM_KEY"
-        gen_base64 1 >/dev/null 2>&1 &&
-            content_line "6) $GW_SET_OBFS_HOST  \033[33m$vms_host\033[0m"
-        btm_box "7) $GW_GEN_SHARE_LINK" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ "$vms_service" = ON ]; then
-                vms_service=OFF
-                setconfig vms_service "$vms_service"
-            else
-                if [ -n "$vms_port" ] && [ -n "$vms_uuid" ]; then
-                    vms_service=ON
-                    setconfig vms_service "$vms_service"
-                else
-                    msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
-                fi
-            fi
-            ;;
-        2)
-            line_break
-            read -r -p "$GW_INPUT_PORT_DEL0> " text
-            if [ "$text" = 0 ]; then
-                vms_port=''
-                setconfig vms_port "" "$GT_CFG_PATH"
-            elif check_port "$text"; then
-                vms_port="$text"
-                setconfig vms_port "$text" "$GT_CFG_PATH"
-            else
-                sleep 1
-            fi
-            ;;
-        3)
-            line_break
-            read -r -p "$GW_INPUT_WSPATH> " text
-            if [ "$text" = 0 ]; then
-                vms_ws_path=''
-                setconfig vms_ws_path "" "$GT_CFG_PATH"
-            elif echo "$text" | grep -qE '^/'; then
-                vms_ws_path="$text"
-                setconfig vms_ws_path "$text" "$GT_CFG_PATH"
-            else
-                msg_alert "\033[31m$GW_ERR_WSPATH\033[0m"
-            fi
-            ;;
-        4)
-            line_break
-            read -r -p "$GW_INPUT_UUID> " text
-            if [ "$text" = 0 ]; then
-                vms_uuid=''
-                setconfig vms_uuid "" "$GT_CFG_PATH"
-            elif echo "$text" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
-                vms_uuid="$text"
-                setconfig vms_uuid "$text" "$GT_CFG_PATH"
-            else
-                msg_alert "\033[31m$GW_ERR_UUID\033[0m"
-            fi
-            ;;
-        5)
-            vms_uuid=$(cat /proc/sys/kernel/random/uuid)
-            setconfig vms_uuid "$vms_uuid" "$GT_CFG_PATH"
-            sleep 1
-            ;;
-        6)
-            line_break
-            read -r -p "$GW_INPUT_OBFS_HOST> " text
-            if [ "$text" = 0 ]; then
-                vms_host=''
-                setconfig vms_host "" "$GT_CFG_PATH"
-            else
-                vms_host="$text"
-                setconfig vms_host "$text" "$GT_CFG_PATH"
-            fi
-            ;;
-        7)
-            line_break
-            read -r -p "$GW_INPUT_HOST> " host_wan
-            if [ -n "$host_wan" ] && [ -n "$vms_port" ] && [ -n "$vms_uuid" ]; then
-                [ -n "$vms_ws_path" ] && vms_net=ws
-                vms_json=$(
-                    cat <<EOF
+	while true; do
+		comp_box "\033[31m$GW_WARN\033[0m" \
+			"$GW_INBOUND_WARN_PORT" \
+			"$GW_INBOUND_WARN_BASIC" \
+			"\033[31m$GW_INBOUND_WARN_ILLEGAL\033[0m"
+		content_line "1) \033[32m$GW_VMS_TOGGLE\033[0m  \033[32m$vms_service\033[0m"
+		content_line "2) $GW_SET_LISTEN_PORT  \033[36m$vms_port\033[0m"
+		content_line "3) $GW_SET_WSPATH  \033[33m$vms_ws_path\033[0m"
+		content_line "4) $GW_SET_UUID  \033[36m$vms_uuid\033[0m"
+		content_line "5) $GW_GEN_RANDOM_KEY"
+		gen_base64 1 >/dev/null 2>&1 &&
+			content_line "6) $GW_SET_OBFS_HOST  \033[33m$vms_host\033[0m"
+		btm_box "7) $GW_GEN_SHARE_LINK" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ "$vms_service" = ON ]; then
+				vms_service=OFF
+				setconfig vms_service "$vms_service"
+			else
+				if [ -n "$vms_port" ] && [ -n "$vms_uuid" ]; then
+					vms_service=ON
+					setconfig vms_service "$vms_service"
+				else
+					msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
+				fi
+			fi
+			;;
+		2)
+			line_break
+			read -r -p "$GW_INPUT_PORT_DEL0> " text
+			if [ "$text" = 0 ]; then
+				vms_port=''
+				setconfig vms_port "" "$GT_CFG_PATH"
+			elif check_port "$text"; then
+				if echo "|$mix_port|$redir_port|$dns_port|$db_port|" | grep -q "|$text|"; then
+					msg_alert "\033[31m$CHECK_PORT_DUP_ERR\033[0m"
+					sleep 1
+				else
+					vms_port="$text"
+					setconfig vms_port "$text" "$GT_CFG_PATH"
+				fi
+			else
+				sleep 1
+			fi
+			;;
+		3)
+			line_break
+			read -r -p "$GW_INPUT_WSPATH> " text
+			if [ "$text" = 0 ]; then
+				vms_ws_path=''
+				setconfig vms_ws_path "" "$GT_CFG_PATH"
+			elif echo "$text" | grep -qE '^/'; then
+				vms_ws_path="$text"
+				setconfig vms_ws_path "$text" "$GT_CFG_PATH"
+			else
+				msg_alert "\033[31m$GW_ERR_WSPATH\033[0m"
+			fi
+			;;
+		4)
+			line_break
+			read -r -p "$GW_INPUT_UUID> " text
+			if [ "$text" = 0 ]; then
+				vms_uuid=''
+				setconfig vms_uuid "" "$GT_CFG_PATH"
+			elif echo "$text" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+				vms_uuid="$text"
+				setconfig vms_uuid "$text" "$GT_CFG_PATH"
+			else
+				msg_alert "\033[31m$GW_ERR_UUID\033[0m"
+			fi
+			;;
+		5)
+			vms_uuid=$(cat /proc/sys/kernel/random/uuid)
+			setconfig vms_uuid "$vms_uuid" "$GT_CFG_PATH"
+			sleep 1
+			;;
+		6)
+			line_break
+			read -r -p "$GW_INPUT_OBFS_HOST> " text
+			if [ "$text" = 0 ]; then
+				vms_host=''
+				setconfig vms_host "" "$GT_CFG_PATH"
+			else
+				vms_host="$text"
+				setconfig vms_host "$text" "$GT_CFG_PATH"
+			fi
+			;;
+		7)
+			line_break
+			read -r -p "$GW_INPUT_HOST> " host_wan
+			if [ -n "$host_wan" ] && [ -n "$vms_port" ] && [ -n "$vms_uuid" ]; then
+				[ -n "$vms_ws_path" ] && vms_net=ws
+				vms_json=$(
+					cat <<EOF
 {
   "v": "2",
   "ps": "ShellCrash_vms_in",
@@ -384,297 +389,301 @@ set_vmess() {
   "host": "$vms_host"
 }
 EOF
-                )
-                vms_link="vmess://$(gen_base64 "$vms_json")"
-                line_break
-                echo -e "$GW_SHARE_LINK_HINT\n\033[32m$vms_link\033[0m"
-                sleep 1
-            else
-                msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
-            fi
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+				)
+				vms_link="vmess://$(gen_base64 "$vms_json")"
+				line_break
+				echo -e "$GW_SHARE_LINK_HINT\n\033[32m$vms_link\033[0m"
+				sleep 1
+			else
+				msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
+			fi
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 set_shadowsocks() {
-    while true; do
-        comp_box "\033[31m$GW_WARN\033[0m" \
-            "$GW_INBOUND_WARN_PORT" \
-            "$GW_INBOUND_WARN_BASIC" \
-            "\033[31m$GW_INBOUND_WARN_ILLEGAL\033[0m"
-        content_line "1) \033[32m$GW_SS_TOGGLE\033[0m  \033[32m$sss_service\033[0m"
-        content_line "2) $GW_SET_LISTEN_PORT  \033[36m$sss_port\033[0m"
-        content_line "3) $GW_SS_SELECT_CIPHER  \033[33m$sss_cipher\033[0m"
-        content_line "4) $GW_SS_SET_PWD  \033[36m$sss_pwd\033[0m"
-        gen_base64 1 >/dev/null 2>&1 &&
-            content_line "5) $GW_GEN_SHARE_LINK"
-        btm_box "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ "$sss_service" = ON ]; then
-                sss_service=OFF
-                setconfig sss_service "$sss_service"
-            else
-                if [ -n "$sss_port" ] && [ -n "$sss_cipher" ] && [ -n "$sss_pwd" ]; then
-                    sss_service=ON
-                    setconfig sss_service "$sss_service"
-                else
-                    msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
-                fi
-            fi
-            ;;
-        2)
-            line_break
-            read -r -p "$GW_INPUT_PORT_DEL0> " text
-            if [ "$text" = 0 ]; then
-                sss_port=''
-                setconfig sss_port "" "$GT_CFG_PATH"
-            elif check_port "$text"; then
-                sss_port="$text"
-                setconfig sss_port "$text" "$GT_CFG_PATH"
-            else
-                sleep 1
-            fi
-            ;;
-        3)
-            comp_box "$GW_SS_SELECT_CIPHER"
-            content_line "1) \033[32mxchacha20-ietf-poly1305\033[0m"
-            content_line "2) \033[32mchacha20-ietf-poly1305\033[0m"
-            content_line "3) \033[32maes-128-gcm\033[0m"
-            content_line "4) \033[32maes-256-gcm\033[0m"
-            gen_random 1 >/dev/null && {
-                content_line ""
-                content_line "$GW_SS_2022_NOTE_HEADER"
-                content_line "$GW_SS_2022_REQUIRE"
-                content_line "5) \033[32m2022-blake3-chacha20-poly1305\033[0m"
-                content_line "6) \033[32m2022-blake3-aes-128-gcm\033[0m"
-                content_line "7) \033[32m2022-blake3-aes-256-gcm\033[0m"
-            }
-            btm_box "" \
-                "0) $COMMON_BACK"
-            read -r -p "$COMMON_INPUT> " num
-            case "$num" in
-            0) ;;
-            1)
-                sss_cipher=xchacha20-ietf-poly1305
-                sss_pwd=$(gen_random 16)
-                ;;
-            2)
-                sss_cipher=chacha20-ietf-poly1305
-                sss_pwd=$(gen_random 16)
-                ;;
-            3)
-                sss_cipher=aes-128-gcm
-                sss_pwd=$(gen_random 16)
-                ;;
-            4)
-                sss_cipher=aes-256-gcm
-                sss_pwd=$(gen_random 16)
-                ;;
-            5)
-                sss_cipher=2022-blake3-chacha20-poly1305
-                sss_pwd=$(gen_random 32)
-                ;;
-            6)
-                sss_cipher=2022-blake3-aes-128-gcm
-                sss_pwd=$(gen_random 16)
-                ;;
-            7)
-                sss_cipher=2022-blake3-aes-256-gcm
-                sss_pwd=$(gen_random 32)
-                ;;
-            *)
-                errornum
-                ;;
-            esac
-            setconfig sss_cipher "$sss_cipher" "$GT_CFG_PATH"
-            setconfig sss_pwd "$sss_pwd" "$GT_CFG_PATH"
-            ;;
-        4)
-            if echo "$sss_cipher" | grep -q '2022-blake3'; then
-                msg_alert "\033[31m$GW_WARN\033[0m$GW_SS_2022_PASSWORD_ONLY"
-            else
-                line_break
-                read -r -p "$GW_INPUT_PWD_DEL0> " text
-                [ "$text" = 0 ] && sss_pwd='' || sss_pwd="$text"
-                setconfig sss_pwd "$text" "$GT_CFG_PATH"
-            fi
-            ;;
-        5)
-            line_break
-            read -r -p "$GW_INPUT_HOST> " text
-            if [ -n "$text" ] && [ -n "$sss_port" ] && [ -n "$sss_cipher" ] && [ -n "$sss_pwd" ]; then
-                ss_link="ss://$(gen_base64 "$sss_cipher":"$sss_pwd")@${text}:${sss_port}#ShellCrash_ss_in"
-                line_break
-                echo -e "$GW_SHARE_LINK_HINT\n\033[32m$ss_link\033[0m"
-                sleep 1
-            else
-                msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
-            fi
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+	while true; do
+		comp_box "\033[31m$GW_WARN\033[0m" \
+			"$GW_INBOUND_WARN_PORT" \
+			"$GW_INBOUND_WARN_BASIC" \
+			"\033[31m$GW_INBOUND_WARN_ILLEGAL\033[0m"
+		content_line "1) \033[32m$GW_SS_TOGGLE\033[0m  \033[32m$sss_service\033[0m"
+		content_line "2) $GW_SET_LISTEN_PORT  \033[36m$sss_port\033[0m"
+		content_line "3) $GW_SS_SELECT_CIPHER  \033[33m$sss_cipher\033[0m"
+		content_line "4) $GW_SS_SET_PWD  \033[36m$sss_pwd\033[0m"
+		gen_base64 1 >/dev/null 2>&1 &&
+			content_line "5) $GW_GEN_SHARE_LINK"
+		btm_box "" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ "$sss_service" = ON ]; then
+				sss_service=OFF
+				setconfig sss_service "$sss_service"
+			else
+				if [ -n "$sss_port" ] && [ -n "$sss_cipher" ] && [ -n "$sss_pwd" ]; then
+					sss_service=ON
+					setconfig sss_service "$sss_service"
+				else
+					msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
+				fi
+			fi
+			;;
+		2)
+			line_break
+			read -r -p "$GW_INPUT_PORT_DEL0> " text
+			if [ "$text" = 0 ]; then
+				sss_port=''
+				setconfig sss_port "" "$GT_CFG_PATH"
+			elif check_port "$text"; then
+				if echo "|$mix_port|$redir_port|$dns_port|$db_port|" | grep -q "|$text|"; then
+					msg_alert "\033[31m$CHECK_PORT_DUP_ERR\033[0m"
+					sleep 1
+				else
+					sss_port="$text"
+					setconfig sss_port "$text" "$GT_CFG_PATH"
+				fi
+			else
+				sleep 1
+			fi
+			;;
+		3)
+			comp_box "$GW_SS_SELECT_CIPHER"
+			content_line "1) \033[32mxchacha20-ietf-poly1305\033[0m"
+			content_line "2) \033[32mchacha20-ietf-poly1305\033[0m"
+			content_line "3) \033[32maes-128-gcm\033[0m"
+			content_line "4) \033[32maes-256-gcm\033[0m"
+			gen_random 1 >/dev/null && {
+				content_line ""
+				content_line "$GW_SS_2022_NOTE_HEADER"
+				content_line "$GW_SS_2022_REQUIRE"
+				content_line "5) \033[32m2022-blake3-chacha20-poly1305\033[0m"
+				content_line "6) \033[32m2022-blake3-aes-128-gcm\033[0m"
+				content_line "7) \033[32m2022-blake3-aes-256-gcm\033[0m"
+			}
+			btm_box "" \
+				"0) $COMMON_BACK"
+			read -r -p "$COMMON_INPUT> " num
+			case "$num" in
+			0) ;;
+			1)
+				sss_cipher=xchacha20-ietf-poly1305
+				sss_pwd=$(gen_random 16)
+				;;
+			2)
+				sss_cipher=chacha20-ietf-poly1305
+				sss_pwd=$(gen_random 16)
+				;;
+			3)
+				sss_cipher=aes-128-gcm
+				sss_pwd=$(gen_random 16)
+				;;
+			4)
+				sss_cipher=aes-256-gcm
+				sss_pwd=$(gen_random 16)
+				;;
+			5)
+				sss_cipher=2022-blake3-chacha20-poly1305
+				sss_pwd=$(gen_random 32)
+				;;
+			6)
+				sss_cipher=2022-blake3-aes-128-gcm
+				sss_pwd=$(gen_random 16)
+				;;
+			7)
+				sss_cipher=2022-blake3-aes-256-gcm
+				sss_pwd=$(gen_random 32)
+				;;
+			*)
+				errornum
+				;;
+			esac
+			setconfig sss_cipher "$sss_cipher" "$GT_CFG_PATH"
+			setconfig sss_pwd "$sss_pwd" "$GT_CFG_PATH"
+			;;
+		4)
+			if echo "$sss_cipher" | grep -q '2022-blake3'; then
+				msg_alert "\033[31m$GW_WARN\033[0m$GW_SS_2022_PASSWORD_ONLY"
+			else
+				line_break
+				read -r -p "$GW_INPUT_PWD_DEL0> " text
+				[ "$text" = 0 ] && sss_pwd='' || sss_pwd="$text"
+				setconfig sss_pwd "$text" "$GT_CFG_PATH"
+			fi
+			;;
+		5)
+			line_break
+			read -r -p "$GW_INPUT_HOST> " text
+			if [ -n "$text" ] && [ -n "$sss_port" ] && [ -n "$sss_cipher" ] && [ -n "$sss_pwd" ]; then
+				ss_link="ss://$(gen_base64 "$sss_cipher":"$sss_pwd")@${text}:${sss_port}#ShellCrash_ss_in"
+				line_break
+				echo -e "$GW_SHARE_LINK_HINT\n\033[32m$ss_link\033[0m"
+				sleep 1
+			else
+				msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
+			fi
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 # 自定义端点
 set_tailscale() {
-    while true; do
-        [ -n "$ts_auth_key" ] && ts_auth_key_info='*********'
-        comp_box "\033[31m$GW_WARN\033[0m$GW_TS_WARN" \
-            "$GW_TS_KEY_URL" \
-            "$GW_TS_ALLOW_URL" \
-            "$GW_TS_SUBNET_EXIT_HINT"
-        btm_box "1) \033[32m$GW_TS_TOGGLE\033[0m  \033[32m$ts_service\033[0m" \
-            "2) $GW_TS_SET_AUTHKEY  $ts_auth_key_info" \
-            "3) $GW_TS_SUBNET  \033[36m$ts_subnet\033[0m" \
-            "4) $GW_TS_EXIT_NODE  \033[36m$ts_exit_node\033[0m" \
-            "5) $GW_TS_HOSTNAME  $ts_hostname" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ -n "$ts_auth_key" ]; then
-                [ "$ts_service" = ON ] && ts_service=OFF || ts_service=ON
-                setconfig ts_service "$ts_service"
-            else
-                msg_alert "\033[31m$GW_TS_SET_KEY_FIRST\033[0m"
-            fi
-            ;;
-        2)
-            line_break
-            read -r -p "$GW_TS_INPUT_KEY> " text
-            [ "$text" = 0 ] && unset ts_auth_key ts_auth_key_info || ts_auth_key="$text"
-            setconfig ts_auth_key "$ts_auth_key" "$GT_CFG_PATH"
-            ;;
-        3)
-            [ "$ts_subnet" = true ] && ts_subnet=false || ts_subnet=true
-            setconfig ts_subnet "$ts_subnet" "$GT_CFG_PATH"
-            ;;
-        4)
-            if [ "$ts_exit_node" = true ]; then
-                ts_exit_node=false
-            else
-                ts_exit_node=true
-                msg_alert -t 3 "\033[31m$GW_WARN\033[0m$GW_TS_EXITNODE_WARN"
-            fi
-            setconfig ts_exit_node "$ts_exit_node" "$GT_CFG_PATH"
-            ;;
-        5)
-            comp_box "\033[36m$GW_TS_INPUT_NAME\033[0m" \
-                "$GW_INPUT_0_BACK"
-            read -r -p "$GW_INPUT_PLAIN> " ts_hostname
-            if [ "$ts_hostname" != 0 ]; then
-                setconfig ts_hostname "$ts_hostname" "$GT_CFG_PATH"
-            fi
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+	while true; do
+		[ -n "$ts_auth_key" ] && ts_auth_key_info='*********'
+		comp_box "\033[31m$GW_WARN\033[0m$GW_TS_WARN" \
+			"$GW_TS_KEY_URL" \
+			"$GW_TS_ALLOW_URL" \
+			"$GW_TS_SUBNET_EXIT_HINT"
+		btm_box "1) \033[32m$GW_TS_TOGGLE\033[0m  \033[32m$ts_service\033[0m" \
+			"2) $GW_TS_SET_AUTHKEY  $ts_auth_key_info" \
+			"3) $GW_TS_SUBNET  \033[36m$ts_subnet\033[0m" \
+			"4) $GW_TS_EXIT_NODE  \033[36m$ts_exit_node\033[0m" \
+			"5) $GW_TS_HOSTNAME  $ts_hostname" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ -n "$ts_auth_key" ]; then
+				[ "$ts_service" = ON ] && ts_service=OFF || ts_service=ON
+				setconfig ts_service "$ts_service"
+			else
+				msg_alert "\033[31m$GW_TS_SET_KEY_FIRST\033[0m"
+			fi
+			;;
+		2)
+			line_break
+			read -r -p "$GW_TS_INPUT_KEY> " text
+			[ "$text" = 0 ] && unset ts_auth_key ts_auth_key_info || ts_auth_key="$text"
+			setconfig ts_auth_key "$ts_auth_key" "$GT_CFG_PATH"
+			;;
+		3)
+			[ "$ts_subnet" = true ] && ts_subnet=false || ts_subnet=true
+			setconfig ts_subnet "$ts_subnet" "$GT_CFG_PATH"
+			;;
+		4)
+			if [ "$ts_exit_node" = true ]; then
+				ts_exit_node=false
+			else
+				ts_exit_node=true
+				msg_alert -t 3 "\033[31m$GW_WARN\033[0m$GW_TS_EXITNODE_WARN"
+			fi
+			setconfig ts_exit_node "$ts_exit_node" "$GT_CFG_PATH"
+			;;
+		5)
+			comp_box "\033[36m$GW_TS_INPUT_NAME\033[0m" \
+				"$GW_INPUT_0_BACK"
+			read -r -p "$GW_INPUT_PLAIN> " ts_hostname
+			if [ "$ts_hostname" != 0 ]; then
+				setconfig ts_hostname "$ts_hostname" "$GT_CFG_PATH"
+			fi
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
 
 set_wireguard() {
-    while true; do
+	while true; do
 
-        if [ -n "$wg_public_key" ]; then
-            wgp_key_info='*********'
-        else
-            unset wgp_key_info
-        fi
+		if [ -n "$wg_public_key" ]; then
+			wgp_key_info='*********'
+		else
+			unset wgp_key_info
+		fi
 
-        if [ -n "$wg_private_key" ]; then
-            wgv_key_info='*********'
-        else
-            unset wgv_key_info
-        fi
+		if [ -n "$wg_private_key" ]; then
+			wgv_key_info='*********'
+		else
+			unset wgv_key_info
+		fi
 
-        if [ -n "$wg_pre_shared_key" ]; then
-            wgpsk_key_info='*********'
-        else
-            unset wgpsk_key_info
-        fi
-        comp_box "\033[31m$GW_WARN\033[0m$GW_WG_WARN"
-        btm_box "1) \033[32m$GW_WG_TOGGLE\033[0m  \033[32m$wg_service\033[0m" \
-            "" \
-            "2) $GW_WG_SET_ENDPOINT  \033[36m$wg_server\033[0m" \
-            "3) $GW_WG_SET_ENDPOINT_PORT  \033[36m$wg_port\033[0m" \
-            "4) $GW_WG_SET_PUBLIC  \033[36m$wgp_key_info\033[0m" \
-            "5) $GW_WG_SET_PRESHARED  \033[36m$wgpsk_key_info\033[0m" \
-            "" \
-            "6) $GW_WG_SET_PRIVATE  \033[33m$wgv_key_info\033[0m" \
-            "7) $GW_WG_SET_IPV4  \033[33m$wg_ipv4\033[0m" \
-            "8) $GW_WG_SET_IPV6  \033[33m$wg_ipv6\033[0m" \
-            "" \
-            "0) $COMMON_BACK"
-        read -r -p "$COMMON_INPUT> " num
-        case "$num" in
-        "" | 0)
-            break
-            ;;
-        1)
-            if [ -n "$wg_server" ] && [ -n "$wg_port" ] && [ -n "$wg_public_key" ] && [ -n "$wg_pre_shared_key" ] && [ -n "$wg_private_key" ] && [ -n "$wg_ipv4" ]; then
-                [ "$wg_service" = ON ] && wg_service=OFF || wg_service=ON
-                setconfig wg_service "$wg_service"
-            else
-                msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
-            fi
-            ;;
-        [1-8])
-            line_break
-            read -r -p "$GW_INPUT_TEXT_DEL0> " text
-            [ "$text" = 0 ] && text=''
-            case "$num" in
-            2)
-                wg_server="$text"
-                setconfig wg_server "$text" "$GT_CFG_PATH"
-                ;;
-            3)
-                wg_port="$text"
-                setconfig wg_port "$text" "$GT_CFG_PATH"
-                ;;
-            4)
-                wg_public_key="$text"
-                setconfig wg_public_key "$text" "$GT_CFG_PATH"
-                ;;
-            5)
-                wg_pre_shared_key="$text"
-                setconfig wg_pre_shared_key "$text" "$GT_CFG_PATH"
-                ;;
-            6)
-                wg_private_key="$text"
-                setconfig wg_private_key "$text" "$GT_CFG_PATH"
-                ;;
-            7)
-                wg_ipv4="$text"
-                setconfig wg_ipv4 "$text" "$GT_CFG_PATH"
-                ;;
-            8)
-                wg_ipv6="$text"
-                setconfig wg_ipv6 "$text" "$GT_CFG_PATH"
-                ;;
-            esac
-            ;;
-        *)
-            errornum
-            ;;
-        esac
-    done
+		if [ -n "$wg_pre_shared_key" ]; then
+			wgpsk_key_info='*********'
+		else
+			unset wgpsk_key_info
+		fi
+		comp_box "\033[31m$GW_WARN\033[0m$GW_WG_WARN"
+		btm_box "1) \033[32m$GW_WG_TOGGLE\033[0m  \033[32m$wg_service\033[0m" \
+			"" \
+			"2) $GW_WG_SET_ENDPOINT  \033[36m$wg_server\033[0m" \
+			"3) $GW_WG_SET_ENDPOINT_PORT  \033[36m$wg_port\033[0m" \
+			"4) $GW_WG_SET_PUBLIC  \033[36m$wgp_key_info\033[0m" \
+			"5) $GW_WG_SET_PRESHARED  \033[36m$wgpsk_key_info\033[0m" \
+			"" \
+			"6) $GW_WG_SET_PRIVATE  \033[33m$wgv_key_info\033[0m" \
+			"7) $GW_WG_SET_IPV4  \033[33m$wg_ipv4\033[0m" \
+			"8) $GW_WG_SET_IPV6  \033[33m$wg_ipv6\033[0m" \
+			"" \
+			"0) $COMMON_BACK"
+		read -r -p "$COMMON_INPUT> " num
+		case "$num" in
+		"" | 0)
+			break
+			;;
+		1)
+			if [ -n "$wg_server" ] && [ -n "$wg_port" ] && [ -n "$wg_public_key" ] && [ -n "$wg_pre_shared_key" ] && [ -n "$wg_private_key" ] && [ -n "$wg_ipv4" ]; then
+				[ "$wg_service" = ON ] && wg_service=OFF || wg_service=ON
+				setconfig wg_service "$wg_service"
+			else
+				msg_alert "\033[31m$GW_FILL_REQUIRED\033[0m"
+			fi
+			;;
+		[1-8])
+			line_break
+			read -r -p "$GW_INPUT_TEXT_DEL0> " text
+			[ "$text" = 0 ] && text=''
+			case "$num" in
+			2)
+				wg_server="$text"
+				setconfig wg_server "$text" "$GT_CFG_PATH"
+				;;
+			3)
+				wg_port="$text"
+				setconfig wg_port "$text" "$GT_CFG_PATH"
+				;;
+			4)
+				wg_public_key="$text"
+				setconfig wg_public_key "$text" "$GT_CFG_PATH"
+				;;
+			5)
+				wg_pre_shared_key="$text"
+				setconfig wg_pre_shared_key "$text" "$GT_CFG_PATH"
+				;;
+			6)
+				wg_private_key="$text"
+				setconfig wg_private_key "$text" "$GT_CFG_PATH"
+				;;
+			7)
+				wg_ipv4="$text"
+				setconfig wg_ipv4 "$text" "$GT_CFG_PATH"
+				;;
+			8)
+				wg_ipv6="$text"
+				setconfig wg_ipv6 "$text" "$GT_CFG_PATH"
+				;;
+			esac
+			;;
+		*)
+			errornum
+			;;
+		esac
+	done
 }
-

--- a/scripts/menus/check_port.sh
+++ b/scripts/menus/check_port.sh
@@ -20,19 +20,6 @@ check_port() {
 		return 1
 	fi
 
-	local current_port_name=""
-	case "$port" in
-	"$mix_port") current_port_name="mix_port" ;;
-	"$redir_port") current_port_name="redir_port" ;;
-	"$dns_port") current_port_name="dns_port" ;;
-	"$db_port") current_port_name="db_port" ;;
-	esac
-
-	if [ -z "$current_port_name" ] && echo "|$mix_port|$redir_port|$dns_port|$db_port|" | grep -q "|$port|"; then
-		msg_alert "\033[31m$CHECK_PORT_DUP_ERR\033[0m"
-		return 1
-	fi
-
 	local check_cmd
 	check_cmd=$(_get_netstat_cmd "$protocol")
 

--- a/scripts/menus/check_port.sh
+++ b/scripts/menus/check_port.sh
@@ -3,17 +3,60 @@
 
 load_lang check_port
 
+_get_netstat_cmd() {
+	case "$1" in
+	tcp) echo "netstat -ntl" ;;
+	udp) echo "netstat -nul" ;;
+	*) echo "netstat -ntul" ;;
+	esac
+}
+
 check_port() {
-    if [ "$1" -gt 65535 ] || [ "$1" -le 1 ]; then
-        msg_alert "\033[31m$CHECK_PORT_RANGE_ERR\033[0m"
-        return 1
-    elif echo "|$mix_port|$redir_port|$dns_port|$db_port|" | grep -q "|$1|"; then
-        msg_alert "\033[31m$CHECK_PORT_DUP_ERR\033[0m"
-        return 1
-    elif netstat -ntul | grep -q ":$1[[:space:]]"; then
-        msg_alert "\033[31m$CHECK_PORT_OCCUPIED_ERR\033[0m"
-        return 1
-    else
-        return 0
-    fi
+	local port="$1"
+	local protocol="${2:-all}"
+
+	if [ "$port" -gt 65535 ] || [ "$port" -le 1 ]; then
+		msg_alert "\033[31m$CHECK_PORT_RANGE_ERR\033[0m"
+		return 1
+	fi
+
+	local current_port_name=""
+	case "$port" in
+	"$mix_port") current_port_name="mix_port" ;;
+	"$redir_port") current_port_name="redir_port" ;;
+	"$dns_port") current_port_name="dns_port" ;;
+	"$db_port") current_port_name="db_port" ;;
+	esac
+
+	if [ -z "$current_port_name" ] && echo "|$mix_port|$redir_port|$dns_port|$db_port|" | grep -q "|$port|"; then
+		msg_alert "\033[31m$CHECK_PORT_DUP_ERR\033[0m"
+		return 1
+	fi
+
+	local check_cmd
+	check_cmd=$(_get_netstat_cmd "$protocol")
+
+	if $check_cmd 2>/dev/null | grep -q ":${port}[[:space:]]"; then
+		msg_alert "\033[31m$CHECK_PORT_OCCUPIED_ERR\033[0m"
+		return 1
+	fi
+
+	return 0
+}
+
+check_port_with_info() {
+	local port="$1"
+	local protocol="${2:-all}"
+	local check_cmd
+	check_cmd=$(_get_netstat_cmd "$protocol")
+
+	local conflict_line
+	conflict_line=$($check_cmd 2>/dev/null | grep ":${port}[[:space:]]" | head -n 1)
+
+	if [ -n "$conflict_line" ]; then
+		echo "$conflict_line"
+		return 1
+	fi
+
+	return 0
 }


### PR DESCRIPTION
Fix #1242

只有 DNS 端口是同时监听 TCP + UDP ，其余均是 TCP 端口，所以检查端口冲突的时候进行端口类型区分，防止误报。

所有修改过的文件全部使用 `shfmt` 格式化