### PR TITLE
优化 web_save 逻辑，确保成功响应再保存

### DIFF
--- a/scripts/libs/web_save.sh
+++ b/scripts/libs/web_save.sh
@@ -1,32 +1,42 @@
-
-#
-get_save() { #获取面板信息
-    if curl --version >/dev/null 2>&1; then
-        curl -s -H "Authorization: Bearer ${secret}" -H "Content-Type:application/json" "$1"
-    elif [ -n "$(wget --help 2>&1 | grep '\-\-method')" ]; then
-        wget -q --header="Authorization: Bearer ${secret}" --header="Content-Type:application/json" -O - "$1"
-    fi
+get_save() { #获取面板信息并内部处理所有异常
+	local response exit_code
+	if curl --version >/dev/null 2>&1; then
+		response=$(curl -sf -H "Authorization: Bearer ${secret}" -H "Content-Type:application/json" "$1" 2>&1)
+		exit_code=$?
+		[ $exit_code -eq 0 ] && [ -n "$response" ] && [ "$response" != "{}" ] && {
+			echo "$response"
+			return 0
+		}
+		return 1
+	elif [ -n "$(wget --help 2>&1 | grep '\-\-method')" ]; then
+		response=$(wget -q --header="Authorization: Bearer ${secret}" --header="Content-Type:application/json" -O - "$1" 2>&1)
+		exit_code=$?
+		[ $exit_code -eq 0 ] && [ -n "$response" ] && [ "$response" != "{}" ] && {
+			echo "$response"
+			return 0
+		}
+		return 1
+	fi
+	return 1
 }
+
 web_save() { #最小化保存面板节点选择
-    #使用get_save获取面板节点设置
-    get_save "http://127.0.0.1:${db_port}/proxies" | sed 's/{}//g' | sed 's/:{/\
-/g'| grep -aE '"Selector"' >"$TMPDIR"/web_proxies
-    [ -s "$TMPDIR"/web_proxies ] && while read line; do
-        def=$(echo $line | grep -oE '"all".*",' | awk -F "[\"]" '{print $4}')
-        now=$(echo $line | grep -oE '"now".*",' | awk -F "[\"]" '{print $4}')
-        [ "$def" != "$now" ] && {
-            name=$(echo $line | grep -oE '"name".*",' | awk -F "[\"]" '{print $4}')
-            echo "${name},${now}" >>"$TMPDIR"/web_save
-        }
-    done <"$TMPDIR"/web_proxies
-    rm -rf "$TMPDIR"/web_proxies
-    #对比文件，如果有变动则写入磁盘，否则清除缓存
-    for file in web_save; do
-        if [ -s "$TMPDIR/$file" ]; then
-            . "$CRASHDIR"/libs/compare.sh && compare "$TMPDIR/$file" "$CRASHDIR/configs/$file"
-            [ "$?" = 0 ] && rm -f "$TMPDIR/$file" || mv -f "$TMPDIR/$file" "$CRASHDIR/configs/$file"
-        else
-            > "$CRASHDIR/configs/$file" #空文件时移除旧文件
-        fi
-    done
+	#使用get_save获取面板节点设置，失败自动退出
+	response=$(get_save "http://127.0.0.1:${db_port}/proxies") || return 1
+
+	echo "$response" | sed 's/{}//g' | sed 's/:{/\
+/g' | grep -aE '"Selector"' >"$TMPDIR"/web_proxies
+
+	>"$TMPDIR"/web_save
+	[ -s "$TMPDIR"/web_proxies ] && while read line; do
+		def=$(echo "$line" | grep -oE '"all".*",' | awk -F "[\"]" '{print $4}')
+		now=$(echo "$line" | grep -oE '"now".*",' | awk -F "[\"]" '{print $4}')
+		[ "$def" != "$now" ] && {
+			name=$(echo "$line" | grep -oE '"name".*",' | awk -F "[\"]" '{print $4}')
+			echo "${name},${now}" >>"$TMPDIR"/web_save
+		}
+	done <"$TMPDIR"/web_proxies
+	rm -f "$TMPDIR"/web_proxies
+	. "$CRASHDIR"/libs/compare.sh && compare "$TMPDIR"/web_save "$CRASHDIR"/configs/web_save
+	[ "$?" = 0 ] && rm -f "$TMPDIR"/web_save || mv -f "$TMPDIR"/web_save "$CRASHDIR"/configs/web_save
 }

--- a/scripts/starts/afstart.sh
+++ b/scripts/starts/afstart.sh
@@ -2,7 +2,11 @@
 # Copyright (C) Juewuy
 
 #初始化目录
-[ -z "$CRASHDIR" ] && CRASHDIR=$( cd $(dirname $0);cd ..;pwd)
+[ -z "$CRASHDIR" ] && CRASHDIR=$(
+	cd $(dirname $0)
+	cd ..
+	pwd
+)
 . "$CRASHDIR"/libs/get_config.sh
 #加载工具
 . "$CRASHDIR"/libs/check_cmd.sh
@@ -12,45 +16,45 @@
 [ -z "$firewall_area" ] && firewall_area=1
 #延迟启动
 [ ! -f "$TMPDIR"/crash_start_time ] && [ -n "$start_delay" ] && [ "$start_delay" -gt 0 ] && {
-    logger "ShellCrash将延迟$start_delay秒启动" 31
-    sleep "$start_delay"
+	logger "ShellCrash将延迟$start_delay秒启动" 31
+	sleep "$start_delay"
 }
 #设置循环检测面板端口以判定服务启动是否成功
 . "$CRASHDIR"/libs/start_wait.sh
 if [ -n "$test" -o -n "$(pidof CrashCore)" ]; then
-    [ "$start_old" = "ON" ] && [ ! -L "$TMPDIR"/CrashCore ] && rm -f "$TMPDIR"/CrashCore	#删除缓存目录内核文件
-    . "$CRASHDIR"/starts/fw_start.sh										#配置防火墙流量劫持
-    date +%s >"$TMPDIR"/crash_start_time                                    #标记启动时间
-    #后台还原面板配置
-    [ -s "$CRASHDIR"/configs/web_save ] && {
-        . "$CRASHDIR"/libs/web_restore.sh
-        web_restore >/dev/null 2>&1 &
-    }
-    #推送日志
-    {
-        sleep 5
-        logger ShellCrash服务已启动！
-    } &
-    ckcmd mtd_storage.sh && mtd_storage.sh save >/dev/null 2>&1 #Padavan保存/etc/storage
-    #加载定时任务
-    cronload | grep -v '^$' > "$TMPDIR"/cron_tmp
-    [ -s "$CRASHDIR"/task/cron ] && cat "$CRASHDIR"/task/cron >> "$TMPDIR"/cron_tmp
-    [ -s "$CRASHDIR"/task/running ] && cat "$CRASHDIR"/task/running >> "$TMPDIR"/cron_tmp
-    [ "$bot_tg_service" = ON ] && echo "* * * * * /bin/sh $CRASHDIR/starts/start_legacy_wd.sh bot_tg #ShellCrash-TG_BOT守护进程" >> "$TMPDIR"/cron_tmp
-    [ "$start_old" = ON ] && echo "* * * * * /bin/sh $CRASHDIR/starts/start_legacy_wd.sh shellcrash #ShellCrash保守模式守护进程" >> "$TMPDIR"/cron_tmp
-    awk '!x[$0]++' "$TMPDIR"/cron_tmp > "$TMPDIR"/cron_tmp2 #删除重复行
-    cronadd "$TMPDIR"/cron_tmp2
-    rm -f "$TMPDIR"/cron_tmp "$TMPDIR"/cron_tmp2
-    #加载条件任务
-    [ -s "$CRASHDIR"/task/afstart ] && { . "$CRASHDIR"/task/afstart; } &
-    [ -s "$CRASHDIR"/task/affirewall -a -s /etc/init.d/firewall -a ! -f /etc/init.d/firewall.bak ] && {
-        #注入防火墙
-        line=$(grep -En "fw.* restart" /etc/init.d/firewall | cut -d ":" -f 1)
-        sed -i.bak "${line}a\\. $CRASHDIR/task/affirewall" /etc/init.d/firewall
-        line=$(grep -En "fw.* start" /etc/init.d/firewall | cut -d ":" -f 1)
-        sed -i "${line}a\\. $CRASHDIR/task/affirewall" /etc/init.d/firewall
-    } &
-    exit 0
+	[ "$start_old" = "ON" ] && [ ! -L "$TMPDIR"/CrashCore ] && rm -f "$TMPDIR"/CrashCore #删除缓存目录内核文件
+	. "$CRASHDIR"/starts/fw_start.sh                                                     #配置防火墙流量劫持
+	date +%s >"$TMPDIR"/crash_start_time                                                 #标记启动时间
+	#还原面板配置
+	[ -s "$CRASHDIR"/configs/web_save ] && {
+		. "$CRASHDIR"/libs/web_restore.sh
+		web_restore >/dev/null 2>&1
+	}
+	#推送日志
+	{
+		sleep 5
+		logger ShellCrash服务已启动！
+	} &
+	ckcmd mtd_storage.sh && mtd_storage.sh save >/dev/null 2>&1 #Padavan保存/etc/storage
+	#加载定时任务
+	cronload | grep -v '^$' >"$TMPDIR"/cron_tmp
+	[ -s "$CRASHDIR"/task/cron ] && cat "$CRASHDIR"/task/cron >>"$TMPDIR"/cron_tmp
+	[ -s "$CRASHDIR"/task/running ] && cat "$CRASHDIR"/task/running >>"$TMPDIR"/cron_tmp
+	[ "$bot_tg_service" = ON ] && echo "* * * * * /bin/sh $CRASHDIR/starts/start_legacy_wd.sh bot_tg #ShellCrash-TG_BOT守护进程" >>"$TMPDIR"/cron_tmp
+	[ "$start_old" = ON ] && echo "* * * * * /bin/sh $CRASHDIR/starts/start_legacy_wd.sh shellcrash #ShellCrash保守模式守护进程" >>"$TMPDIR"/cron_tmp
+	awk '!x[$0]++' "$TMPDIR"/cron_tmp >"$TMPDIR"/cron_tmp2 #删除重复行
+	cronadd "$TMPDIR"/cron_tmp2
+	rm -f "$TMPDIR"/cron_tmp "$TMPDIR"/cron_tmp2
+	#加载条件任务
+	[ -s "$CRASHDIR"/task/afstart ] && { . "$CRASHDIR"/task/afstart; } &
+	[ -s "$CRASHDIR"/task/affirewall -a -s /etc/init.d/firewall -a ! -f /etc/init.d/firewall.bak ] && {
+		#注入防火墙
+		line=$(grep -En "fw.* restart" /etc/init.d/firewall | cut -d ":" -f 1)
+		sed -i.bak "${line}a\\. $CRASHDIR/task/affirewall" /etc/init.d/firewall
+		line=$(grep -En "fw.* start" /etc/init.d/firewall | cut -d ":" -f 1)
+		sed -i "${line}a\\. $CRASHDIR/task/affirewall" /etc/init.d/firewall
+	} &
+	exit 0
 else
-    . "$CRASHDIR"/starts/start_error.sh
+	. "$CRASHDIR"/starts/start_error.sh
 fi


### PR DESCRIPTION
- `web_save` 和 `get_save` 增加状态码判断，只有成功才正常返回
- 调用者可以直接根据退出码判断是否执行成功
- 执行失败时不覆盖 `configs/web_save` 文件，防止web UI 配置丢失
- 所有修改过的文件使用 `shfmt` 格式化