### PR TITLE
修复 ipv6 DNS 拦截错误的网段

### DIFF
--- a/scripts/starts/fw_getlanip.sh
+++ b/scripts/starts/fw_getlanip.sh
@@ -1,9 +1,10 @@
-
 getlanip() { #获取局域网host地址
     i=1
     while [ "$i" -le "20" ]; do
-        host_ipv4=$(ip route show scope link | grep -Ev 'wan|utun|iot|peer|docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet' | awk '{print $1}') #ipv4局域网网段
-        [ "$ipv6_redir" = "ON" ] && host_ipv6=$(ip -6 route show default | awk '{print $3}' | tr '\n' ' ' | sed 's/ $//') #ipv6公网地址段
+        #ipv4局域网网段
+        host_ipv4=$(ip route show scope link | grep -Ev 'wan|utun|iot|peer|docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet' | awk '{print $1}')
+        #ipv6局域网网段
+        [ "$ipv6_redir" = "ON" ] && host_ipv6=$(ip -6 route show | grep -Ev 'default|unreachable|fe80::/|wan|ppp|utun|iot|peer|docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet' | awk '{print $1}' | tr '\n' ' ' | sed 's/ $//')
         [ -f "$TMPDIR"/ShellCrash.log ] && break
         [ -n "$host_ipv4" -a "$ipv6_redir" != "ON" ] && break
         [ -n "$host_ipv4" -a -n "$host_ipv6" ] && break
@@ -24,7 +25,7 @@ getlanip() { #获取局域网host地址
     if [ "$replace_default_host_ipv4" == "ON" ]; then
         host_ipv4="$cust_host_ipv4"
     else
-        host_ipv4=$(echo "$host_ipv4 $cust_host_ipv4$ts_host_ipv4$wg_host_ipv4"| tr '\n' ' ' | sed 's/ $//')
+        host_ipv4=$(echo "$host_ipv4 $cust_host_ipv4$ts_host_ipv4$wg_host_ipv4" | tr '\n' ' ' | sed 's/ $//')
     fi
     #缺省配置
     [ -z "$host_ipv4" ] && {


### PR DESCRIPTION
之前获取本机 ipv6 地址的逻辑有误，将得到 `fe80::` 前缀的地址，导致本地网络 ipv6 DNS 不走核心

现在修复这个问题