### PR TITLE
优化域名嗅探

### DIFF
--- a/scripts/starts/clash_modify.sh
+++ b/scripts/starts/clash_modify.sh
@@ -67,7 +67,7 @@ EOF
         fi
     }
     #域名嗅探配置
-    [ "$sniffer" = "ON" ] && [ "$crashcore" = "meta" ] && sniffer_set="sniffer: {enable: true, parse-pure-ip: true, skip-domain: [Mijia Cloud], sniff: {http: {ports: [80, 8080-8880], override-destination: true}, tls: {ports: [443, 8443]}, quic: {ports: [443, 8443]}}}"
+    [ "$sniffer" = "ON" ] && [ "$crashcore" = "meta" ] && sniffer_set="sniffer: {enable: true, parse-pure-ip: true, skip-domain: ['+.push.apple.com', 'Mijia Cloud'], sniff: {http: {ports: [80, 8080-8880], override-destination: true}, tls: {ports: [443, 8443]}, quic: {ports: [443, 8443]}}}"
     [ "$crashcore" = "clashpre" ] && [ "$dns_mod" = "redir_host" -o "$sniffer" = "ON" ] && exper="experimental: {ignore-resolve-fail: true, interface-name: en0,sniff-tls-sni: true}"
     #生成set.yaml
     cat >"$TMPDIR"/set.yaml <<EOF

--- a/scripts/starts/singbox_modify.sh
+++ b/scripts/starts/singbox_modify.sh
@@ -205,7 +205,7 @@ EOF
 EOF
     #生成add_route.json
     #域名嗅探配置
-    [ "$sniffer" != OFF ] && sniffer_set='{ "action": "sniff", "timeout": "500ms" },'
+    [ "$sniffer" != OFF ] && sniffer_set='{ "domain_suffix": [ "push.apple.com" ], "rule_set": [ "telegramip" ], "domain": [ "Mijia Cloud" ], "invert": true, "action": "sniff", "timeout": "500ms" },'
     [ "$ts_service" = ON ] && tailscale_set='{ "inbound": [ "ts-ep" ], "port": 53, "action": "hijack-dns" },'
     cat >"$TMPDIR"/jsons/add_route.json <<EOF
 {


### PR DESCRIPTION
1. 俩内核的域名嗅探都排除了 `+.push.apple.com`
2. sing-box 内核排除了 `"domain": [ "Mijia Cloud" ]`，根据 https://github.com/SagerNet/sing-box/blob/25052a2aa42fb8bab579a4c96fa398448c1be91b/common/sniff/tls.go#L25 是可以匹配的。另外也排除了 `"rule_set": [ "telegramip" ]`，避免电报 IP 规则匹配上私有网络并在日志中刷报错信息。这条有争议，部分用户没有新增 `telegramip` 规则集，您可以删除此条