### PR TITLE
Refactor clash_modify.sh and singbox_modify.sh into modular helper functions

### DIFF
--- a/scripts/starts/clash_modify.sh
+++ b/scripts/starts/clash_modify.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # Copyright (C) Juewuy
 
-#修饰clash配置文件
-modify_yaml() {
+prepare_clash_base_config() {
     ##########需要变更的配置###########
     [ "$ipv6_dns" != "OFF" ] && dns_v6='true' || dns_v6='false'
     external="external-controller: 0.0.0.0:$db_port"
@@ -69,6 +68,9 @@ EOF
     #域名嗅探配置
     [ "$sniffer" = "ON" ] && [ "$crashcore" = "meta" ] && sniffer_set="sniffer: {enable: true, parse-pure-ip: true, skip-domain: ['+.push.apple.com', 'Mijia Cloud'], sniff: {http: {ports: [80, 8080-8880], override-destination: true}, tls: {ports: [443, 8443]}, quic: {ports: [443, 8443]}}}"
     [ "$crashcore" = "clashpre" ] && [ "$dns_mod" = "redir_host" -o "$sniffer" = "ON" ] && exper="experimental: {ignore-resolve-fail: true, interface-name: en0,sniff-tls-sni: true}"
+}
+
+generate_set_and_hosts_yaml() {
     #生成set.yaml
     cat >"$TMPDIR"/set.yaml <<EOF
 mixed-port: $mix_port
@@ -114,6 +116,9 @@ EOF
                 echo "  '$hosts_domain': $hosts_ip" >>"$TMPDIR"/hosts.yaml
         done
     fi
+}
+
+split_and_customize_yaml_parts() {
     #分割配置文件
     yaml_char='proxies proxy-groups proxy-providers rules rule-providers sub-rules listeners'
     for char in $yaml_char; do
@@ -173,6 +178,9 @@ EOF
             IFS="$oldIFS"
         done
     }
+}
+
+add_custom_inbounds_and_rules() {
     #添加自定义入站
     [ "$vms_service" = ON ] || [ "$sss_service" = ON ] && {
         . "$CRASHDIR"/configs/gateway.cfg
@@ -193,6 +201,9 @@ EOF
         cat "$TMPDIR"/rules.yaml >>"$TMPDIR"/rules.add
         mv -f "$TMPDIR"/rules.add "$TMPDIR"/rules.yaml
     }
+}
+
+generate_rule_providers_and_merge_yaml() {
     #mix和route模式生成rule-providers
     [ "$dns_mod" = "mix" ] || [ "$dns_mod" = "route" ] && ! grep -Eq '^[[:space:]]*cn:' "$TMPDIR"/rule-providers.yaml && ! grep -q '^rule-providers' "$CRASHDIR"/yamls/others.yaml 2>/dev/null && {
         space=$(sed -n "1p" "$TMPDIR"/rule-providers.yaml | grep -oE '^ *') #获取空格数
@@ -222,6 +233,9 @@ EOF
     done
     #合并完整配置文件
     cut -c 1- "$TMPDIR"/set.yaml $yaml_dns $yaml_hosts $yaml_user $yaml_others $yaml_add >"$TMPDIR"/config.yaml
+}
+
+validate_and_rebuild_yaml_if_needed() {
     #测试自定义配置文件
     "$TMPDIR"/CrashCore -t -d "$BINDIR" -f "$TMPDIR"/config.yaml >/dev/null
     if [ "$?" != 0 ]; then
@@ -235,10 +249,24 @@ EOF
         cut -c 1- "$TMPDIR"/set.yaml $yaml_dns $yaml_add >"$TMPDIR"/config.yaml
         sed -i "/#自定义/d" "$TMPDIR"/config.yaml
     fi
+}
+
+finalize_clash_yaml() {
     #建立软连接
     [ ""$TMPDIR"" = ""$BINDIR"" ] || ln -sf "$TMPDIR"/config.yaml "$BINDIR"/config.yaml 2>/dev/null || cp -f "$TMPDIR"/config.yaml "$BINDIR"/config.yaml
     #清理缓存
     for char in $yaml_char set set_bak dns hosts; do
         rm -f "$TMPDIR"/${char}.yaml
     done
+}
+
+#修饰clash配置文件
+modify_yaml() {
+    prepare_clash_base_config
+    generate_set_and_hosts_yaml
+    split_and_customize_yaml_parts
+    add_custom_inbounds_and_rules
+    generate_rule_providers_and_merge_yaml
+    validate_and_rebuild_yaml_if_needed
+    finalize_clash_yaml
 }

--- a/scripts/starts/singbox_modify.sh
+++ b/scripts/starts/singbox_modify.sh
@@ -41,7 +41,7 @@ parse_singbox_dns() { #dns转换
     # 输出
     echo '"type": "'"$type"'", "server": "'"$server"'", "server_port": '"$port"','
 }
-modify_json() {
+extract_base_jsons() {
     #提取配置文件以获得outbounds.json,providers.json及route.json
     "$TMPDIR"/CrashCore format -c $core_config >"$TMPDIR"/format.json
     echo '{' >"$TMPDIR"/jsons/outbounds.json
@@ -52,6 +52,9 @@ modify_json() {
         cat "$TMPDIR"/format.json | sed -n '/^  "providers":/,/^  "[a-z]/p' | sed '$d' >>"$TMPDIR"/jsons/providers.json
     }
     cat "$TMPDIR"/format.json | sed -n '/"route":/,/^\(  "[a-z]\|}\)/p' | sed '$d' >>"$TMPDIR"/jsons/route.json
+}
+
+generate_basic_jsons() {
     #生成endpoints.json
     [ "$ts_service" = ON ] || [ "$wg_service" = ON ] && [ "$zip_type" != upx ] && {
         . "$CRASHDIR"/configs/gateway.cfg
@@ -96,6 +99,9 @@ EOF
 }
 EOF
     fi
+}
+
+prepare_dns_config() {
     #生成dns.json
     [ "$ipv6_dns" != "OFF" ] && strategy='prefer_ipv4' || strategy='ipv4_only'
     #获取detour出口
@@ -131,6 +137,9 @@ EOF
     }
     #防泄露设置
     [ "$dns_protect" = "OFF" ] && sed -i 's/"server": "dns_proxy"/"server": "dns_direct"/g' "$TMPDIR"/jsons/route.json
+}
+
+generate_dns_related_jsons() {
     #生成add_rule_set.json
     [ "$dns_mod" = "mix" ] || [ "$dns_mod" = "route" ] && ! grep -Eq '"tag" *:[[:space:]]*"cn"' "$CRASHDIR"/jsons/*.json && {
         [ "$crashcore" = "singboxr" ] && srs_path='"path": "./ruleset/cn.srs",'
@@ -203,6 +212,9 @@ EOF
   }
 }
 EOF
+}
+
+generate_route_and_inbounds_jsons() {
     #生成add_route.json
     #域名嗅探配置
     [ "$sniffer" != OFF ] && sniffer_set='{ "domain_suffix": [ "push.apple.com" ], "rule_set": [ "telegramip" ], "domain": [ "Mijia Cloud" ], "invert": true, "action": "sniff", "timeout": "500ms" },'
@@ -292,6 +304,9 @@ EOF
 }
 EOF
     fi
+}
+
+generate_outbounds_and_experimental_jsons() {
     #生成add_outbounds.json
     grep -qE '"tag": "DIRECT"' "$TMPDIR"/jsons/outbounds.json || add_direct='{ "tag": "DIRECT", "type": "direct" }'
     grep -qE '"tag": "REJECT"' "$TMPDIR"/jsons/outbounds.json || add_reject='{ "tag": "REJECT", "type": "block" }'
@@ -325,6 +340,9 @@ EOF
   }
 }
 EOF
+}
+
+generate_custom_rules_json() {
     #生成自定义规则文件
     [ -n "$(grep -Ev ^# "$CRASHDIR"/yamls/rules.yaml 2>/dev/null)" ] && {
         cat "$CRASHDIR"/yamls/rules.yaml |
@@ -348,6 +366,9 @@ EOF
             sed '$s/,$/ ] } }/' >"$TMPDIR"/jsons/cust_add_rules.json
         [ ! -s "$TMPDIR"/jsons/cust_add_rules.json ] && rm -rf "$TMPDIR"/jsons/cust_add_rules.json
     }
+}
+
+normalize_and_finalize_jsons() {
     #清理route.json中的process_name规则以及"auto_detect_interface"
     sed -i '/"process_name": \[/,/],$/d' "$TMPDIR"/jsons/route.json
     sed -i '/"process_name": "[^"]*",/d' "$TMPDIR"/jsons/route.json
@@ -367,6 +388,9 @@ EOF
             rm -rf "$TMPDIR"/jsons/${file}.json
         fi
     done
+}
+
+link_custom_jsons() {
     #加载自定义配置文件
     mkdir -p "$TMPDIR"/jsons_base
     #以下为覆盖脚本的自定义文件
@@ -382,6 +406,9 @@ EOF
             ln -sf "$CRASHDIR"/jsons/${char}.json "$TMPDIR"/jsons/cust_${char}.json
         }
     done
+}
+
+validate_and_restore_custom_jsons() {
     #测试自定义配置文件
     if ! error=$("$TMPDIR"/CrashCore check -D "$BINDIR" -C "$TMPDIR"/jsons 2>&1); then
         echo $error
@@ -393,6 +420,19 @@ EOF
         rm -rf "$TMPDIR"/jsons/cust_*
         mv -f "$TMPDIR"/jsons_base/* "$TMPDIR"/jsons 2>/dev/null
     fi
+}
+
+modify_json() {
+    extract_base_jsons
+    generate_basic_jsons
+    prepare_dns_config
+    generate_dns_related_jsons
+    generate_route_and_inbounds_jsons
+    generate_outbounds_and_experimental_jsons
+    generate_custom_rules_json
+    normalize_and_finalize_jsons
+    link_custom_jsons
+    validate_and_restore_custom_jsons
     #清理缓存
     rm -rf "$TMPDIR"/*.json
     rm -rf "$TMPDIR"/jsons_base


### PR DESCRIPTION
### Motivation

- Improve readability and maintainability by splitting large monolithic `modify_yaml`/`modify_json` functions into smaller, focused helpers. 
- Make it easier to insert, validate and restore custom YAML/JSON parts and to reuse each processing step independently.

### Description

- In `scripts/starts/clash_modify.sh` the original `modify_yaml` was refactored into: `prepare_clash_base_config`, `generate_set_and_hosts_yaml`, `split_and_customize_yaml_parts`, `add_custom_inbounds_and_rules`, `generate_rule_providers_and_merge_yaml`, `validate_and_rebuild_yaml_if_needed`, and `finalize_clash_yaml`, with `modify_yaml` now orchestrating those calls. 
- In `scripts/starts/singbox_modify.sh` the original `modify_json` was refactored into: `extract_base_jsons`, `generate_basic_jsons`, `prepare_dns_config`, `generate_dns_related_jsons`, `generate_route_and_inbounds_jsons`, `generate_outbounds_and_experimental_jsons`, `generate_custom_rules_json`, `normalize_and_finalize_jsons`, `link_custom_jsons`, and `validate_and_restore_custom_jsons`, with `modify_json` now invoking them in sequence. 
- Kept existing behavior and content generation (DNS/hosts/proxies/rules/outbounds/providers/etc.) while adding clearer separation of concerns and localized validation/restore steps.

### Testing

- Performed a shell syntax check on the modified scripts with `sh -n` and no syntax errors were reported. 
- No automated integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45cb30aa483278e7dfc9a044640b1)