### PR TITLE
优化Docker构建和部署逻辑，改进配置持久化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime && \
 #复制文件
 COPY --from=builder /etc/ShellCrash /etc/ShellCrash
 COPY --from=builder /tmp/CrashCore.tar.gz /etc/ShellCrash/CrashCore.tar.gz
+RUN cp -a /etc/ShellCrash /etc/ShellCrash_backup
 COPY --from=builder /etc/profile /etc/profile
 COPY --from=builder /usr/bin/crash /usr/bin/crash
 
@@ -74,6 +75,7 @@ COPY --from=builder /tmp/s6_noarch.tar.xz /tmp/s6_noarch.tar.xz
 RUN tar -xJf /tmp/s6_noarch.tar.xz -C / && rm -rf /tmp/s6_noarch.tar.xz
 RUN tar -xJf /tmp/s6_arch.tar.xz -C / && rm -rf /tmp/s6_arch.tar.xz
 COPY docker/s6-rc.d /etc/s6-overlay/s6-rc.d
+RUN chmod +x /etc/s6-overlay/s6-rc.d/sc-init/up
 ENV S6_CMD_WAIT_FOR_SERVICES=1
 
 ENTRYPOINT ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ COPY --from=builder /tmp/s6_noarch.tar.xz /tmp/s6_noarch.tar.xz
 RUN tar -xJf /tmp/s6_noarch.tar.xz -C / && rm -rf /tmp/s6_noarch.tar.xz
 RUN tar -xJf /tmp/s6_arch.tar.xz -C / && rm -rf /tmp/s6_arch.tar.xz
 COPY docker/s6-rc.d /etc/s6-overlay/s6-rc.d
-RUN chmod +x /etc/s6-overlay/s6-rc.d/sc-init/up
 ENV S6_CMD_WAIT_FOR_SERVICES=1
 
 ENTRYPOINT ["/init"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,7 +88,7 @@ mkdir -p /root/ShellCrash
 ```shell
 docker run -d \
   ………………
-  -v shellcrash_configs:/etc/ShellCrash/configs \
+  -v shellcrash_configs:/etc/ShellCrash \
   ………………
 ```
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -17,7 +17,7 @@ services:
       - net.ipv4.ip_forward: 1
       # - net.ipv6.conf.all.forwarding=1
     volumes:
-      - shellcrash_configs:/etc/ShellCrash/configs:rw
+      - shellcrash_configs:/etc/ShellCrash:rw
     restart: unless-stopped
     
 volumes:

--- a/docker/s6-rc.d/sc-init/type
+++ b/docker/s6-rc.d/sc-init/type
@@ -1,0 +1,1 @@
+oneshot

--- a/docker/s6-rc.d/sc-init/up
+++ b/docker/s6-rc.d/sc-init/up
@@ -1,5 +1,10 @@
-#!/bin/sh
-if [ ! -d "/etc/ShellCrash" ] || [ -z "$(ls -A /etc/ShellCrash 2>/dev/null)" ]; then
-    mkdir -p /etc/ShellCrash
-    cp -a /etc/ShellCrash_backup/. /etc/ShellCrash/
-fi
+#!/command/execlineb -P
+foreground {
+  if { test ! -d /etc/ShellCrash }
+  mkdir -p /etc/ShellCrash
+}
+foreground {
+  if { sh -c "[ -z \"$(ls -A /etc/ShellCrash 2>/dev/null)\" ]" }
+  cp -a /etc/ShellCrash_backup/. /etc/ShellCrash/
+}
+exit 0

--- a/docker/s6-rc.d/sc-init/up
+++ b/docker/s6-rc.d/sc-init/up
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ ! -d "/etc/ShellCrash" ] || [ -z "$(ls -A /etc/ShellCrash 2>/dev/null)" ]; then
+    mkdir -p /etc/ShellCrash
+    cp -a /etc/ShellCrash_backup/. /etc/ShellCrash/
+fi


### PR DESCRIPTION
修改点：

1. 在构建镜像的时候，把安装好的`/etc/ShellCrash`另外存一份副本。
2. 在S6注册一个`sc-init`，如果启动容器时`/etc/ShellCrash`不存在或者为空，就把副本拷贝过去。
3. 把持久化挂载目录从`/etc/ShellCrash/configs`改成`/etc/ShellCrash`。

这样可以保留所有的用户配置，不受删除容器的影响，在我的设备上可以按预期工作。

但是，这样修改之后会有个小问题，就是镜像的更新和程序本体的更新脱钩了。对于新部署的用户来说是没问题的，但是以后即使更新镜像也不会更新已经挂载了持久化目录的程序本体。我能想到的方案有以下两个：

1. 镜像本身只提供运行环境和最新程序本体的副本。如果Docker用户希望更新程序本体，就进入程序内的`更新与支持`来更新。
2. 在更新程序时，为Docker另外写一个更新脚本。当用户运行更新之后的容器时，就根据脚本来更新对应的程序文件。

希望作者可以想出更完善的解决方案