### PR TITLE
修复某些情况下引入的default字段污染变量

### DIFF
--- a/scripts/starts/fw_getlanip.sh
+++ b/scripts/starts/fw_getlanip.sh
@@ -2,7 +2,7 @@ getlanip() { #获取局域网host地址
     i=1
     while [ "$i" -le "20" ]; do
         #ipv4局域网网段
-        host_ipv4=$(ip route show scope link | grep -Ev 'wan|utun|iot|peer|docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet|wgs|multicast|anycast' | awk '{print $1}')
+        host_ipv4=$(ip route show scope link | grep -Ev 'default|wan|utun|iot|peer|docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet|wgs|multicast|anycast' | awk '{print $1}')
         #ipv6局域网网段 - 从IPv4已识别的LAN接口获取全局IPv6前缀
         [ "$ipv6_redir" = "ON" ] && {
             lan_ifaces=$(ip route show scope link | grep -Ev 'ppp|wan|utun|iot|peer|docker|podman|virbr|vnet|ovs|vmbr|veth|vmnic|vboxnet|lxcbr|xenbr|vEthernet|wgs|multicast|anycast' | awk '{for(i=1;i<=NF;i++) if($i=="dev") {print $(i+1); break}}' | grep -v '^lo$' | sort -u)


### PR DESCRIPTION
```
Error: Could not resolve hostname: Name does not resolve
add rule inet shellcrash input ip saddr {default, 10.17.1.0/24, 192.0.0.1, 192.0.0.2, 192.168.150.0/23} accept
                                         ^^^^^^^
Error: Could not resolve hostname: Name does not resolve
add rule inet shellcrash prerouting_dns ip saddr != {default, 10.17.1.0/24, 192.0.0.1, 192.0.0.2, 192.168.150.0/23} return
                                                     ^^^^^^^
Error: Could not resolve hostname: Name does not resolve
add rule inet shellcrash prerouting ip saddr != {default, 10.17.1.0/24, 192.0.0.1, 192.0.0.2, 192.168.150.0/23} return
```

使用过程中遇到变量过滤不全的问题