### PR TITLE
fix: 修复 upx 内核切换后首次启动重复下载内核的问题

### DIFF
--- a/scripts/libs/core_tools.sh
+++ b/scripts/libs/core_tools.sh
@@ -53,7 +53,7 @@ core_check(){
         fi
         if [ "$zip_type" = 'upx' ];then
             rm -f "$1" "$TMPDIR"/core_new
-            ln -sf "$TMPDIR/CrashCore.upx" "$TMPDIR/CrashCore"
+            ln -sf "$BINDIR/CrashCore.upx" "$TMPDIR/CrashCore"
         else
             mv -f "$TMPDIR/core_new" "$TMPDIR/CrashCore"
         fi


### PR DESCRIPTION
切换到 upx 内核后第一次启动，会提示"未找到核心"然后重新下载一遍刚下好的内核。

原因：core_check 的 upx 分支把内核文件 mv 到了 $BINDIR/CrashCore.upx，但 $TMPDIR/CrashCore 这个符号链接指向的却是 $TMPDIR/CrashCore.upx（不存在），是个断链。BusyBox 路由器上 check_core 本来能靠 core_find 自愈重建链接，但 BusyBox 的 find 不支持 -size，还会把断链本身当成结果列出来，于是 core_find 被跳过、断链没修上，被判成内核缺失，触发重新下载。

把链接指向 $BINDIR/CrashCore.upx 即可。只有 upx 受影响，tar.gz / gz 都是直接放真实文件，没这个问题。