### PR TITLE
修复 singbox 内核 ECS 获取失败导致启动 FATAL

### DIFF
--- a/scripts/libs/get_ecsip.sh
+++ b/scripts/libs/get_ecsip.sh
@@ -6,8 +6,9 @@ get_ecs_address() {
         [ -n "$ip" ] && return
     done
     . "$CRASHDIR"/libs/web_get_lite.sh
-    for web in http://members.3322.org/dyndns/getip http://4.ipw.cn http://ipinfo.io/ip; do
-        ip=$(web_get_lite "$web" 0)
+    #轮询公网IP，提取并校验为合法IPv4才采用，否则继续尝试下一个
+    for web in http://ddns.oray.com/checkip http://members.3322.org/dyndns/getip http://ipinfo.io/ip; do
+        ip=$(web_get_lite "$web" 0 | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}' | tail -1)
         [ -n "$ip" ] && return
     done
 }

--- a/scripts/starts/clash_modify.sh
+++ b/scripts/starts/clash_modify.sh
@@ -21,7 +21,7 @@ prepare_clash_base_config() {
             if [ -n "$ecs_address" ];then
                 dns_fallback=$(echo "$dns_fallback, " | sed "s|, |#ecs-override=true\&ecs=$ecs_address, |g" | sed 's|, $||')
             else
-                logger "自动获取ecs网段失败！"
+                logger "自动获取ecs网段失败！" 33
             fi
         }
     }

--- a/scripts/starts/singbox_modify.sh
+++ b/scripts/starts/singbox_modify.sh
@@ -113,7 +113,11 @@ prepare_dns_config() {
     #ecs优化
     [ "$ecs_subnet" = ON ] && {
         . "$CRASHDIR"/libs/get_ecsip.sh
-        client_subnet='"client_subnet": "'"$ecs_address"'",'
+        if [ -n "$ecs_address" ]; then
+            client_subnet='"client_subnet": "'"$ecs_address"'",'
+        else
+            logger "自动获取ecs网段失败！" 33
+        fi
     }
     #根据dns模式生成
     [ "$dns_mod" = "redir_host" ] && {


### PR DESCRIPTION
## 问题

开启 ECS 优化（`ecs_subnet=ON`）后，`get_ecsip.sh` 获取公网 IP 失败时，`singbox_modify.sh` 仍写入空值 `"client_subnet": ""`，导致 sing-box 启动 FATAL：

```
FATAL dns.client_subnet: netip.ParsePrefix(""): no '/'
```

mihomo 分支因已有判空保护不受影响。

另外 `get_ecsip.sh` 的公网 IP 轮询形同虚设：`[ -n "$ip" ]` 只判非空，`members.3322.org` 被限流返回 429 HTML 错误页时也判为成功 return，后续更可靠的源不会被尝试。

## 修复

- `get_ecsip.sh`：每个响应用 `grep -oE` 提取合法 IPv4，提取失败（HTML/空）则继续轮询下一个；新增 `ddns.oray.com/checkip` 放首位（响应为 `Current IP Address: x.x.x.x`，grep 提取末尾 IPv4），移除部分运营商不可解析的 `4.ipw.cn`
- `singbox_modify.sh`：补 `ecs_address` 判空，失败时不写字段，与 mihomo 分支对齐
- `clash_modify.sh`：原告警 `logger` 缺颜色码只写日志不打印终端，补 `33`