### PR TITLE
core: 按环境权衡 rom/RAM 取舍决定内核存储形态

### DIFF
--- a/scripts/libs/core_tools.sh
+++ b/scripts/libs/core_tools.sh
@@ -14,6 +14,8 @@ core_unzip() { #$1:需要解压的文件 $2:目标文件名
         rm -rf "$TMPDIR"/core_tmp
     elif echo "$1" |grep -q '.gz$' ;then
         gunzip -c "$1" > "$TMPDIR"/"$2"
+    elif echo "$1" |grep -q '.raw$' ;then
+        ln -sf "$1" "$TMPDIR"/"$2"
     elif echo "$1" |grep -q '.upx$' ;then
         ln -sf "$1" "$TMPDIR"/"$2"
     else
@@ -45,16 +47,27 @@ core_check(){
         rm -rf "$1" "$TMPDIR"/core_new
         return 2
     else
-        rm -f "$BINDIR"/CrashCore.tar.gz "$BINDIR"/CrashCore.gz "$BINDIR"/CrashCore.upx
-        if [ -z "$zip_type" ];then
+        rm -f "$BINDIR"/CrashCore.tar.gz "$BINDIR"/CrashCore.gz "$BINDIR"/CrashCore.upx "$BINDIR"/CrashCore.raw
+        #$TMPDIR为内存(tmpfs)且$BINDIR为透明压缩文件系统(squashfs/ubifs)时，直接以裸二进制存于$BINDIR并软链，省内存
+        store_raw=0
+        tmp_fs=$(df -T "$TMPDIR" 2>/dev/null | awk 'END{print $2}')
+        rom_fs=$(df -T "$BINDIR" 2>/dev/null | awk 'END{print $2}')
+        case "$tmp_fs" in tmpfs|ramfs)
+            case "$rom_fs" in squashfs|ubifs|overlay|overlayfs) store_raw=1 ;; esac ;;
+        esac
+        if [ "$zip_type" = 'upx' ];then
+            mv -f "$1" "$BINDIR/CrashCore.upx"
+            rm -f "$TMPDIR"/core_new
+            ln -sf "$BINDIR/CrashCore.upx" "$TMPDIR/CrashCore"
+        elif [ "$store_raw" = 1 ];then
+            rm -f "$1"
+            mv -f "$TMPDIR/core_new" "$BINDIR/CrashCore.raw"
+            ln -sf "$BINDIR/CrashCore.raw" "$TMPDIR/CrashCore"
+        elif [ -z "$zip_type" ];then
             gzip -c "$TMPDIR/core_new" > "$BINDIR/CrashCore.gz"
+            mv -f "$TMPDIR/core_new" "$TMPDIR/CrashCore"
         else
             mv -f "$1" "$BINDIR/CrashCore.$zip_type"
-        fi
-        if [ "$zip_type" = 'upx' ];then
-            rm -f "$1" "$TMPDIR"/core_new
-            ln -sf "$TMPDIR/CrashCore.upx" "$TMPDIR/CrashCore"
-        else
             mv -f "$TMPDIR/core_new" "$TMPDIR/CrashCore"
         fi
         core_v="$v"

--- a/scripts/libs/core_tools.sh
+++ b/scripts/libs/core_tools.sh
@@ -2,6 +2,14 @@
 
 [ -n "$(find --help 2>&1 | grep -o size)" ] && find_para=' -size +2000'             #find命令兼容
 
+#$TMPDIR为内存(tmpfs)且$BINDIR在透明压缩文件系统(squashfs/ubifs/overlay)上时返回0
+#此类设备应把裸二进制存于$BINDIR(rom透明压缩)并软链，而非解压/memfd占用内存
+store_on_rom(){
+    case "$(df -T "$TMPDIR" 2>/dev/null | awk 'END{print $2}')" in tmpfs|ramfs) ;; *) return 1 ;; esac
+    case "$(df -T "$BINDIR" 2>/dev/null | awk 'END{print $2}')" in squashfs|ubifs|overlay|overlayfs) return 0 ;; esac
+    return 1
+}
+
 core_unzip() { #$1:需要解压的文件 $2:目标文件名
     if echo "$1" |grep -q 'tar.gz$' ;then
         [ "$BINDIR" = "$TMPDIR" ] && rm -rf "$TMPDIR"/CrashCore #小闪存模式防止空间不足
@@ -48,18 +56,11 @@ core_check(){
         return 2
     else
         rm -f "$BINDIR"/CrashCore.tar.gz "$BINDIR"/CrashCore.gz "$BINDIR"/CrashCore.upx "$BINDIR"/CrashCore.raw
-        #$TMPDIR为内存(tmpfs)且$BINDIR为透明压缩文件系统(squashfs/ubifs)时，直接以裸二进制存于$BINDIR并软链，省内存
-        store_raw=0
-        tmp_fs=$(df -T "$TMPDIR" 2>/dev/null | awk 'END{print $2}')
-        rom_fs=$(df -T "$BINDIR" 2>/dev/null | awk 'END{print $2}')
-        case "$tmp_fs" in tmpfs|ramfs)
-            case "$rom_fs" in squashfs|ubifs|overlay|overlayfs) store_raw=1 ;; esac ;;
-        esac
         if [ "$zip_type" = 'upx' ];then
             mv -f "$1" "$BINDIR/CrashCore.upx"
             rm -f "$TMPDIR"/core_new
             ln -sf "$BINDIR/CrashCore.upx" "$TMPDIR/CrashCore"
-        elif [ "$store_raw" = 1 ];then
+        elif store_on_rom ;then
             rm -f "$1"
             mv -f "$TMPDIR/core_new" "$BINDIR/CrashCore.raw"
             ln -sf "$BINDIR/CrashCore.raw" "$TMPDIR/CrashCore"
@@ -83,6 +84,8 @@ core_webget(){
     . "$CRASHDIR"/libs/check_target.sh
     if [ -z "$custcorelink" ];then
         [ -z "$zip_type" ] && zip_type='tar.gz'
+        #压缩rom+内存tmp设备避免下载upx(运行时memfd占RAM)，改取tar.gz的裸二进制存于rom
+        [ "$zip_type" = 'upx' ] && store_on_rom && zip_type='tar.gz'
         get_bin "$TMPDIR/Coretmp.$zip_type" "bin/$crashcore/${target}-linux-${cpucore}.$zip_type"
     else
         case "$custcorelink" in

--- a/scripts/libs/core_tools.sh
+++ b/scripts/libs/core_tools.sh
@@ -2,12 +2,18 @@
 
 [ -n "$(find --help 2>&1 | grep -o size)" ] && find_para=' -size +2000'             #find命令兼容
 
-#$TMPDIR为内存(tmpfs)且$BINDIR在透明压缩文件系统(squashfs/ubifs/overlay)上时返回0
-#此类设备应把裸二进制存于$BINDIR(rom透明压缩)并软链，而非解压/memfd占用内存
-store_on_rom(){
+#根据环境权衡决定是否把裸二进制存于$BINDIR(rom)——省RAM，前提是rom装得下
+#$1=裸二进制字节数。仅当$TMPDIR在内存(tmpfs)时裸存才省RAM；
+#再按$BINDIR文件系统估算裸二进制落盘体积(透明压缩fs约2:1)，需留有余量($raw_margin,默认8M)
+store_raw_worth_it(){
     case "$(df -T "$TMPDIR" 2>/dev/null | awk 'END{print $2}')" in tmpfs|ramfs) ;; *) return 1 ;; esac
-    case "$(df -T "$BINDIR" 2>/dev/null | awk 'END{print $2}')" in squashfs|ubifs|overlay|overlayfs) return 0 ;; esac
-    return 1
+    rom_free=$(df -k "$BINDIR" 2>/dev/null | awk 'END{print $4}')          #KB
+    [ -z "$rom_free" ] && return 1
+    case "$(df -T "$BINDIR" 2>/dev/null | awk 'END{print $2}')" in
+        squashfs|ubifs|overlay|overlayfs) est=$(( ${1:-0}/1024/2 )) ;;    #透明压缩，约2:1
+        *) est=$(( ${1:-0}/1024 )) ;;                                     #无压缩，全量
+    esac
+    [ $(( rom_free - est )) -gt "${raw_margin:-8192}" ] && return 0 || return 1
 }
 
 core_unzip() { #$1:需要解压的文件 $2:目标文件名
@@ -60,7 +66,7 @@ core_check(){
             mv -f "$1" "$BINDIR/CrashCore.upx"
             rm -f "$TMPDIR"/core_new
             ln -sf "$BINDIR/CrashCore.upx" "$TMPDIR/CrashCore"
-        elif store_on_rom ;then
+        elif store_raw_worth_it "$(wc -c < "$TMPDIR/core_new")" ;then
             rm -f "$1"
             mv -f "$TMPDIR/core_new" "$BINDIR/CrashCore.raw"
             ln -sf "$BINDIR/CrashCore.raw" "$TMPDIR/CrashCore"
@@ -84,8 +90,8 @@ core_webget(){
     . "$CRASHDIR"/libs/check_target.sh
     if [ -z "$custcorelink" ];then
         [ -z "$zip_type" ] && zip_type='tar.gz'
-        #压缩rom+内存tmp设备避免下载upx(运行时memfd占RAM)，改取tar.gz的裸二进制存于rom
-        [ "$zip_type" = 'upx' ] && store_on_rom && zip_type='tar.gz'
+        #若环境适合裸存(见store_raw_worth_it，按典型核心~45M估算)，避免下载upx，改取tar.gz的裸二进制
+        [ "$zip_type" = 'upx' ] && store_raw_worth_it 47185920 && zip_type='tar.gz'
         get_bin "$TMPDIR/Coretmp.$zip_type" "bin/$crashcore/${target}-linux-${cpucore}.$zip_type"
     else
         case "$custcorelink" in


### PR DESCRIPTION
For #1304

## 问题

内核存哪种形态、放哪里，现在只看压缩包大小，没按设备环境权衡 rom 与 RAM 的取舍。以约 40M 的核心为例，几种形态的大致成本：

| 形态 | rom 占用 | RAM 占用（tmp=tmpfs） |
|---|---|---|
| gz（解压到 tmp） | 10M | ~40M（tmpfs，不可回收） |
| upx（memfd 执行） | 9M | ~40M+（memfd 就是 RAM） |
| 裸二进制 / 压缩 fs | ~15M | **0**（file-backed 可回收） |
| 裸二进制 / 非压缩 fs | ~40M | **0** |

OpenWrt 上 `$TMPDIR` 是 tmpfs（RAM），rom 多为 squashfs/ubifs（透明压缩）。此时 upx 反而最费 RAM（stub 在 exec 时 `memfd_create` 把整个程序解压回内存），而 upx 却被当作小设备的首选格式（`general_init.sh` 里非 upx 才需把 `/tmp` 撑到 45M）。512MB 的 ipq60xx 上 `MemAvailable` 因此只剩约 40M。

## 改动

按环境计算偏好，而非写死某种格式。新增 `store_raw_worth_it()`：当 `$TMPDIR` 在内存（tmpfs）**且** `$BINDIR` 能容纳裸二进制（按 fs 估算落盘体积——压缩 fs 约 2:1，否则全量——并预留余量）时，才把裸二进制存于 rom。

- **rom 装得下裸二进制** → 存 `$BINDIR/CrashCore.raw`、`$TMPDIR/CrashCore` 软链、丢压缩包。rom 上被透明压缩，运行时 file-backed 可回收（`RssShmem` 归零）。压缩 fs 上裸二进制约 15M，几乎总是划算；非压缩 fs 上仅当 rom 有余量才选。
- **rom 逼迫 / tmp 非内存** → 维持现状（rom 留压缩件，解压到 tmp）。rom 稀缺时压缩形态更优。

`core_webget` 也据此在裸存可行时跳过 upx 核心、改取 tar.gz（拿到裸二进制）。`.raw` 只是落盘形态不是下载格式；`core_find` 的 `CrashCore.*` glob 配合 `core_unzip` 新增的 `.raw` 分支在启动时重建软链。用户显式指定的 upx / 自定义链接维持原行为。顺带修正 upx 分支软链目标 `$TMPDIR`→`$BINDIR`（与 #1295 同一处悬空 bug）。

## 效果（ipq60xx, ImmortalWrt 25.12）

```
                改动前          改动后
MemAvailable    39900 kB        75724 kB
Shmem           45128 kB          980 kB
RssShmem        36876 kB            0 kB
RssFile           176 kB        36096 kB
/tmp 占用        45.1 MB          2.0 MB
```

## 验证

在真实 fs（`$BINDIR` 于 overlay/ubifs、`$TMPDIR` 于 tmpfs）上跑通：

- **rom 有余量**：`store_raw_worth_it` 成立（实测 20.1 余量 12M、10.1 余量 31M，均 > 8M）→ 存 `CrashCore.raw`、软链、可执行。
- **rom 逼迫**（调大余量阈值模拟）→ 回退存 `CrashCore.gz`、解压到 tmp。
- **tmp 非内存**（df 伪装 ext4）→ 不裸存（裸存不省 RAM）。
- **config `zip_type=upx` + 裸存可行**：默认核心下载被覆盖为 tar.gz → 存 raw。
- **自定义 `.upx` 为裸二进制**：软链到 rom、运行时 `RssShmem=0`。
- **重启**：`core_find` 重建软链指向 `$BINDIR`。

fs 估算比例（2:1）与余量阈值（8M）为保守默认，可调。
