### PR TITLE
适配 sing-box 内核规则集新特性

### DIFF
--- a/scripts/starts/singbox_modify.sh
+++ b/scripts/starts/singbox_modify.sh
@@ -169,7 +169,7 @@ gen_dns() {
     #防泄露设置
     [ "$dns_protect" = "OFF" ] && sed -i 's/"server": "dns_proxy"/"server": "dns_direct"/g' "$TMPDIR"/jsons/route.json
     #生成add_rule_set.json
-    [ "$dns_mod" = "mix" ] || [ "$dns_mod" = "route" ] && ! grep -Eq '"tag" *:[[:space:]]*"cn"' "$CRASHDIR"/jsons/*.json && {
+    [ "$dns_mod" = "mix" ] || [ "$dns_mod" = "route" ] && ! grep -Eq '"tag" *:[[:space:]]*"cn"' "$CRASHDIR"/jsons/*.json && ! grep -Eq '"tag"[[:space:]]*:[[:space:]]*\[[^]]*"cn"' "$CRASHDIR"/jsons/*.json && {
         [ "$crashcore" = "singboxr" ] && srs_path='"path": "./ruleset/cn.srs",'
         cat >"$TMPDIR"/jsons/add_rule_set.json <<EOF
 {


### PR DESCRIPTION
`route.rule_set.tag` 支持了[数组](https://sing-box.sagernet.org/zh/configuration/rule-set/#__tabbed_1_3)，修改后避免报错“cn 规则集重复”。