### PR TITLE
feat: 增加可选的 UDP 缓冲上限设置

### DIFF
--- a/scripts/lang/chs/2_settings.lang
+++ b/scripts/lang/chs/2_settings.lang
@@ -10,6 +10,7 @@ SET_MENU_SKIP_CERT="跳过证书验证："
 SET_MENU_SNIFFER="启用域名嗅探："
 SET_MENU_ADV_PORT="自定义端口及密钥"
 SET_MENU_IPV6="IPv6设置：   "
+SET_MENU_UDP_BUFFER="提高UDP缓冲上限(16 MiB)："
 SET_MENU_RESET="重置/备份/还原脚本设置"
 SET_MENU_LANG="多语言切换"
 SET_MENU_UI="UI切换"
@@ -26,6 +27,9 @@ SET_SNIFFER_LOCKED="当前内核与DNS模式组合下，域名嗅探无法关闭
 
 SET_CORE_RUNNING="检测到服务正在运行，需要先停止服务！"
 SET_CORE_STOP_CONFIRM="是否确认停止服务？"
+SET_UDP_BUFFER_ON="已启用UDP缓冲上限优化！"
+SET_UDP_BUFFER_OFF="已禁用UDP缓冲上限优化，现有系统值不会被降低。"
+SET_UDP_BUFFER_RESTART="重启服务后对新连接生效。"
 
 # =================================================
 # Backup / Restore / Reset

--- a/scripts/lang/en/2_settings.lang
+++ b/scripts/lang/en/2_settings.lang
@@ -10,6 +10,7 @@ SET_MENU_SKIP_CERT="Skip Cert Verify:"
 SET_MENU_SNIFFER="Enable Sniff:"
 SET_MENU_ADV_PORT="Custom Ports and Secrets"
 SET_MENU_IPV6="IPv6 Settings:"
+SET_MENU_UDP_BUFFER="Raise UDP Buffer Limit (16 MiB):"
 SET_MENU_RESET="Reset / Backup / Restore Script Settings"
 SET_MENU_LANG="Language"
 SET_MENU_UI="UI Switch"
@@ -26,6 +27,9 @@ SET_SNIFFER_LOCKED="Domain sniffing cannot be disabled with the current core and
 
 SET_CORE_RUNNING="Service is currently running and must be stopped first!"
 SET_CORE_STOP_CONFIRM="Do you want to stop the service?"
+SET_UDP_BUFFER_ON="UDP buffer limit optimization is now enabled!"
+SET_UDP_BUFFER_OFF="UDP buffer limit optimization is now disabled. Existing system values will not be lowered."
+SET_UDP_BUFFER_RESTART="Restart the service to apply it to new connections."
 
 # =================================================
 # Backup / Restore / Reset

--- a/scripts/menus/2_settings.sh
+++ b/scripts/menus/2_settings.sh
@@ -16,6 +16,7 @@ settings() {
             echo "$crashcore" | grep -q 'singbox' && sniffer=ON
         }
         [ -z "$dns_mod" ] && dns_mod='redir_host'
+        [ -z "$udp_buffer" ] && udp_buffer=OFF
 
         comp_box "\033[30;47m$SET_MENU_TITLE\033[0m"
         content_line "1) $SET_MENU_REDIR\t\033[36m$redir_mod$MENU_MOD\033[0m"
@@ -27,6 +28,7 @@ settings() {
             content_line "6) $SET_MENU_ADV_PORT"
         }
         content_line "7) $SET_MENU_IPV6\t\033[36m$ipv6_redir\033[0m"
+        content_line "8) $SET_MENU_UDP_BUFFER\t\033[36m$udp_buffer\033[0m"
         btm_box "" \
             "a) \033[31m$SET_MENU_RESET\033[0m" \
             "b) \033[36m$SET_MENU_LANG\033[0m" \
@@ -142,6 +144,18 @@ settings() {
             ;;
         7)
             set_ipv6
+            ;;
+        8)
+            if [ "$udp_buffer" = "ON" ]; then
+                udp_buffer=OFF
+                msg_alert "\033[33m$SET_UDP_BUFFER_OFF\033[0m" \
+                    "$SET_UDP_BUFFER_RESTART"
+            else
+                udp_buffer=ON
+                msg_alert "\033[32m$SET_UDP_BUFFER_ON\033[0m" \
+                    "$SET_UDP_BUFFER_RESTART"
+            fi
+            setconfig udp_buffer "$udp_buffer"
             ;;
         a)
             BACK_TAR="$CRASHDIR/configs.tar.gz"

--- a/scripts/starts/bfstart.sh
+++ b/scripts/starts/bfstart.sh
@@ -27,7 +27,9 @@ set_udp_buffer_limit() {
     [ "$udp_buffer" = "ON" ] || return 0
 
     udp_buffer_limit=16777216
-    for udp_buffer_file in /proc/sys/net/core/rmem_max /proc/sys/net/core/wmem_max; do
+    #同时提高上限与默认值：部分Mihomo/quic-go构建不显式setsockopt，仅继承default
+    for udp_buffer_file in /proc/sys/net/core/rmem_max /proc/sys/net/core/wmem_max \
+        /proc/sys/net/core/rmem_default /proc/sys/net/core/wmem_default; do
         [ -w "$udp_buffer_file" ] || continue
         udp_buffer_current=$(cat "$udp_buffer_file" 2>/dev/null)
         case "$udp_buffer_current" in

--- a/scripts/starts/bfstart.sh
+++ b/scripts/starts/bfstart.sh
@@ -23,6 +23,22 @@
 [ -z "$redir_mod" ] && firewall_area='4'
 routing_mark=$((fwmark + 2))
 
+set_udp_buffer_limit() {
+    [ "$udp_buffer" = "ON" ] || return 0
+
+    udp_buffer_limit=16777216
+    for udp_buffer_file in /proc/sys/net/core/rmem_max /proc/sys/net/core/wmem_max; do
+        [ -w "$udp_buffer_file" ] || continue
+        udp_buffer_current=$(cat "$udp_buffer_file" 2>/dev/null)
+        case "$udp_buffer_current" in
+        '' | *[!0-9]*) continue ;;
+        esac
+        [ "$udp_buffer_current" -lt "$udp_buffer_limit" ] &&
+            printf '%s\n' "$udp_buffer_limit" >"$udp_buffer_file"
+    done
+    unset udp_buffer_limit udp_buffer_file udp_buffer_current
+}
+
 makehtml() { #生成面板跳转文件
     cat >"$BINDIR"/ui/index.html <<EOF
 <!DOCTYPE html>
@@ -78,6 +94,8 @@ EOF
 [ "$network_check" != "OFF" ] && [ ! -f "$TMPDIR"/crash_start_time ] && ckcmd ping && . "$CRASHDIR"/starts/check_network.sh && check_network
 [ ! -d "$BINDIR"/ui ] && mkdir -p "$BINDIR"/ui
 [ -z "$crashcore" ] && crashcore=meta
+#按需提高UDP套接字缓冲上限，改善Hysteria2等QUIC协议的吞吐
+set_udp_buffer_limit
 #执行条件任务
 [ -s "$TASKCFGDIR"/bfstart ] && . "$TASKCFGDIR"/bfstart
 #检查内核配置文件


### PR DESCRIPTION
小米/红米官方固件默认把内核 UDP 缓冲限制在 229376 字节（`rmem_max/wmem_max` 及默认值 `rmem_default/wmem_default`），导致 Mihomo 使用 Hysteria2/QUIC 时吞吐严重受限。

实测（百兆宽带，经路由器透明代理）：
- 修复前：约 0.2–0.8 MB/s
- 四项均提高至 16 MiB 后：9–15 MB/s，已跑满线路

部分 Mihomo/quic-go 构建不显式调用 setsockopt，socket 缓冲直接继承内核 default 值，因此仅提高 `max` 无法生效，需同时提高 `default`。

本次在功能设置中新增独立开关（默认关闭）。开启后仅在 CrashCore 启动前把低于 16 MiB 的 `rmem_max`/`wmem_max`/`rmem_default`/`wmem_default` 提高至 16 MiB；不覆盖用户已有的更高值，关闭时不会降低现有系统值。