### PR TITLE
忽略 macOS .DS_Store 文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
如题，在 .gitignore 内忽略 macOS 的 .DS_Store 文件