### PR TITLE
chore: add practical gitignore template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
+# Operating system files
 .DS_Store
+.DS_Store?
+._*
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.stackdump
+
+# Editor temporary files
+*.swp
+*.swo
+*~
+.#*
+
+# Workflow temporary files
+bin/dashboard/.tmp/


### PR DESCRIPTION
## Summary

- Expand `.gitignore` into a practical cross-platform template for this shell project
- Ignore OS metadata and editor temporary files
- Ignore the Dashboard workflow scratch directory at `bin/dashboard/.tmp/`
- Avoid unrelated Node, environment, build, and runtime patterns that do not apply to this repository

## Verification

- `git diff --check`
- Confirmed no tracked files are ignored by the new rules