### PR TITLE
修复 compose 中, 删除重建容器, 开机自启功能失效

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,10 @@ COPY --from=builder /tmp/s6_noarch.tar.xz /tmp/s6_noarch.tar.xz
 RUN tar -xJf /tmp/s6_noarch.tar.xz -C / && rm -rf /tmp/s6_noarch.tar.xz
 RUN tar -xJf /tmp/s6_arch.tar.xz -C / && rm -rf /tmp/s6_arch.tar.xz
 COPY docker/s6-rc.d /etc/s6-overlay/s6-rc.d
+COPY docker/s6-overlay/scripts/sync-autostart /etc/s6-overlay/scripts/sync-autostart
+RUN chmod +x /etc/s6-overlay/scripts/sync-autostart
 ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_STAGE2_HOOK=/etc/s6-overlay/scripts/sync-autostart
 
 ENTRYPOINT ["/init"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -89,6 +89,8 @@ mkdir -p /root/ShellCrash
 docker run -d \
   ………………
   -v shellcrash_configs:/etc/ShellCrash/configs \
+  -v shellcrash_yamls:/etc/ShellCrash/yamls \
+  -v shellcrash_jsons:/etc/ShellCrash/jsons \
   ………………
 ```
 
@@ -134,7 +136,7 @@ docker rm -f shellcrash
 ### Docker删除卷
 
 ```shell
-docker volume rm shellcrash_configs
+docker volume rm shellcrash_configs shellcrash_yamls shellcrash_jsons
 ```
 
 ### Compose删除容器&卷

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -18,10 +18,14 @@ services:
       # - net.ipv6.conf.all.forwarding=1
     volumes:
       - shellcrash_configs:/etc/ShellCrash/configs:rw
+      - shellcrash_yamls:/etc/ShellCrash/yamls:rw
+      - shellcrash_jsons:/etc/ShellCrash/jsons:rw
     restart: unless-stopped
     
 volumes:
   shellcrash_configs:
+  shellcrash_yamls:
+  shellcrash_jsons:
   
 networks:
   macvlan_lan:

--- a/docker/s6-overlay/scripts/sync-autostart
+++ b/docker/s6-overlay/scripts/sync-autostart
@@ -1,0 +1,22 @@
+#!/bin/sh
+# 在 s6-rc 编译 user bundle 之前，把 configs 卷中的自启状态同步到 contents.d
+# 由 S6_STAGE2_HOOK 调用；删除重建容器后仍可按 volume 恢复开机自启
+
+CRASHDIR=/etc/ShellCrash
+CFG_MARK="$CRASHDIR/configs/.autostart"
+S6_MARK=/etc/s6-overlay/s6-rc.d/user/contents.d/afstart
+
+mkdir -p "$CRASHDIR/configs" /etc/s6-overlay/s6-rc.d/user/contents.d
+
+# 兼容旧容器：仅有 s6 标记时迁移到 configs
+if [ -f "$S6_MARK" ] && [ ! -f "$CFG_MARK" ]; then
+    touch "$CFG_MARK"
+fi
+
+if [ -f "$CFG_MARK" ] && [ ! -f "$CRASHDIR/.dis_startup" ]; then
+    touch "$S6_MARK"
+else
+    rm -f "$S6_MARK"
+fi
+
+exit 0

--- a/scripts/libs/check_autostart.sh
+++ b/scripts/libs/check_autostart.sh
@@ -1,3 +1,22 @@
+# s6 / Docker：自启状态以 configs 卷内标记为准，并同步到 s6 contents.d
+
+enable_s6_autostart_marks() {
+    mkdir -p "$CRASHDIR/configs" /etc/s6-overlay/s6-rc.d/user/contents.d
+    touch "$CRASHDIR/configs/.autostart" /etc/s6-overlay/s6-rc.d/user/contents.d/afstart
+}
+
+disable_s6_autostart_marks() {
+    rm -f "$CRASHDIR/configs/.autostart" /etc/s6-overlay/s6-rc.d/user/contents.d/afstart
+}
+
+# 将旧版仅写在可写层的 s6 标记迁移到 configs
+migrate_s6_autostart_mark() {
+    if [ -f /etc/s6-overlay/s6-rc.d/user/contents.d/afstart ] && [ ! -f "$CRASHDIR/configs/.autostart" ]; then
+        mkdir -p "$CRASHDIR/configs"
+        touch "$CRASHDIR/configs/.autostart"
+    fi
+}
+
 check_autostart(){
     if [ "$start_old" = ON ];then
         [ ! -f "$CRASHDIR"/.dis_startup ] && return 0
@@ -7,7 +26,8 @@ check_autostart(){
     elif ckcmd systemctl; then
         [ "$(systemctl is-enabled shellcrash.service 2>&1)" = enabled ] && return 0
     elif grep -q 's6' /proc/1/comm; then
-        [ -f /etc/s6-overlay/s6-rc.d/user/contents.d/afstart ] && return 0
+        migrate_s6_autostart_mark
+        [ -f "$CRASHDIR/configs/.autostart" ] && [ ! -f "$CRASHDIR"/.dis_startup ] && return 0
     elif rc-status -r >/dev/null 2>&1; then
         rc-update show default | grep -q "shellcrash" && return 0
     else

--- a/scripts/menus/4_setboot.sh
+++ b/scripts/menus/4_setboot.sh
@@ -12,7 +12,7 @@ allow_autostart() {
     fi
 
     ckcmd systemctl && systemctl enable shellcrash.service >/dev/null 2>&1
-    grep -q 's6' /proc/1/comm && touch /etc/s6-overlay/s6-rc.d/user/contents.d/afstart
+    grep -q 's6' /proc/1/comm && enable_s6_autostart_marks
     rc-status -r >/dev/null 2>&1 && rc-update add shellcrash default >/dev/null 2>&1
     rm -rf "$CRASHDIR"/.dis_startup
 }
@@ -20,7 +20,7 @@ allow_autostart() {
 disable_autostart() {
     [ -d /etc/rc.d ] && cd /etc/rc.d && rm -rf *shellcrash >/dev/null 2>&1 && cd - >/dev/null
     ckcmd systemctl && systemctl disable shellcrash.service >/dev/null 2>&1
-    grep -q 's6' /proc/1/comm && rm -rf /etc/s6-overlay/s6-rc.d/user/contents.d/afstart
+    grep -q 's6' /proc/1/comm && disable_s6_autostart_marks
     rc-status -r >/dev/null 2>&1 && rc-update del shellcrash default >/dev/null 2>&1
     touch "$CRASHDIR"/.dis_startup
 }

--- a/scripts/menus/userguide.sh
+++ b/scripts/menus/userguide.sh
@@ -69,6 +69,7 @@ forwhat() {
             fi
 
             ckcmd systemctl && [ "$(cat /proc/1/comm)" = "systemd" ] && systemctl enable shellcrash.service >/dev/null 2>&1
+            grep -q 's6' /proc/1/comm && enable_s6_autostart_marks
             rm -rf "$CRASHDIR"/.dis_startup
             autostart=enable
             # 检测IP转发

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -11,6 +11,7 @@
 . "$CRASHDIR"/libs/set_config.sh
 . "$CRASHDIR"/libs/set_cron.sh
 . "$CRASHDIR"/libs/check_cmd.sh
+. "$CRASHDIR"/libs/check_autostart.sh
 . "$CRASHDIR"/libs/compare.sh
 . "$CRASHDIR"/libs/logger.sh
 . "$CRASHDIR"/libs/web_save.sh
@@ -54,7 +55,7 @@ start)
         systemctl start shellcrash.service || . "$CRASHDIR"/starts/start_error.sh
     elif grep -q 's6' /proc/1/comm; then
         bfstart && /command/s6-svc -u /run/service/shellcrash && {
-            [ ! -f "$CRASHDIR"/.dis_startup ] && touch /etc/s6-overlay/s6-rc.d/user/contents.d/afstart
+            [ ! -f "$CRASHDIR"/.dis_startup ] && enable_s6_autostart_marks
             afstart &
         }
     elif rc-status -r >/dev/null 2>&1; then


### PR DESCRIPTION
解决两个问题, 一个是开机自启的配置项位置放到持久卷里, 防止开关状态消失
另一个是核心配置持久化, 防止重建容器自动启动失败

目前已测试通过的镜像
``` yml
services:
  shellcrash:
    image: purewhiteicecream/shellcrash:1.9.5beta3
    container_name: shellcrash
    cap_add:
      - SYS_ADMIN
      - NET_ADMIN
      - NET_RAW
    devices:
      - "/dev/net/tun:/dev/net/tun"
    sysctls:
      - net.ipv4.ip_forward=1
      # - net.ipv6.conf.all.forwarding=1
    volumes:
      - configs:/etc/ShellCrash/configs:rw
      - yamls:/etc/ShellCrash/yamls:rw
    ports:
      - "7890:7890" # 代理 mixed 端口
      - "9999:9999" # Web 面板端口
    restart: always

volumes:
  configs:
  yamls:

```